### PR TITLE
Fix scan stuck + missing files: timeouts, stale checkpoint, scan_min_…

### DIFF
--- a/apps/bridge-agent/src/api-client.ts
+++ b/apps/bridge-agent/src/api-client.ts
@@ -20,6 +20,7 @@ async function callApi(action: string, payload: Record<string, unknown> = {}): P
           "x-agent-key": config.agentKey,
         },
         body,
+        signal: AbortSignal.timeout(30_000), // 30s hard timeout per request — prevents hung connections stalling the scan
       });
 
       if (!res.ok) {
@@ -125,7 +126,7 @@ export interface HeartbeatResponse {
   ok: boolean;
   config?: {
     do_spaces?: { key: string; secret: string; bucket: string; region: string; endpoint: string };
-    scanning?: { container_mount_root: string; roots: string[]; batch_size: number; adaptive_polling: { idle_seconds: number; active_seconds: number } };
+    scanning?: { container_mount_root: string; roots: string[]; batch_size: number; scan_min_date?: string | null; adaptive_polling: { idle_seconds: number; active_seconds: number } };
     resource_guard?: { cpu_percentage_limit: number; memory_limit_mb: number; concurrency: number };
     windows_render_mode?: "fallback_only" | "primary";
     windows_render_policy?: WindowsRenderPolicy | null;

--- a/apps/bridge-agent/src/index.ts
+++ b/apps/bridge-agent/src/index.ts
@@ -261,8 +261,9 @@ function applyCloudConfig(cfg: CloudConfig) {
     if (cfg.scanning.batch_size) {
       cloudBatchSize = cfg.scanning.batch_size;
     }
-    if (cfg.scanning.scan_min_date) {
-      cloudScanMinDate = cfg.scanning.scan_min_date;
+    if (cfg.scanning.scan_min_date !== undefined) {
+      // Explicitly assign even when null — null means "clear the date filter"
+      cloudScanMinDate = cfg.scanning.scan_min_date ?? null;
     }
   }
 
@@ -361,19 +362,38 @@ async function runScan(providedSessionId?: string) {
   let resumeFromDir: string | undefined;
 
   // ── Check for resumable checkpoint ──
+  const CHECKPOINT_MAX_AGE_MS = 12 * 60 * 60 * 1000; // 12 hours — beyond this, treat as stale
   try {
     const checkpoint = await api.getCheckpoint();
     if (checkpoint && checkpoint.last_completed_dir) {
-      // Resume from last completed directory regardless of session match.
-      // Same session = crashed mid-scan and restarted.
-      // Different session = previous scan crashed, new one requested.
-      logger.info("Found checkpoint, resuming scan", {
-        checkpointSession: checkpoint.session_id,
-        currentSession: sessionId,
-        lastCompletedDir: checkpoint.last_completed_dir,
-        savedAt: checkpoint.saved_at,
-      });
-      resumeFromDir = checkpoint.last_completed_dir;
+      const ageMs = Date.now() - new Date(checkpoint.saved_at).getTime();
+      const isDifferentSession = checkpoint.session_id !== sessionId;
+
+      if (isDifferentSession && ageMs > CHECKPOINT_MAX_AGE_MS) {
+        // Checkpoint is from a different scan that completed long ago — likely a failed clearCheckpoint.
+        // Discarding it prevents skipping directories on a fresh scan.
+        logger.warn("Discarding stale checkpoint (different session, too old)", {
+          checkpointSession: checkpoint.session_id,
+          currentSession: sessionId,
+          savedAt: checkpoint.saved_at,
+          ageHours: Math.round(ageMs / 3_600_000),
+        });
+        await api.clearCheckpoint().catch((e) =>
+          logger.warn("Failed to clear stale checkpoint", { error: (e as Error).message })
+        );
+      } else {
+        // Resume from last completed directory.
+        // Same session = crashed mid-scan and restarted.
+        // Different session (recent) = previous scan crashed, new one requested.
+        logger.info("Found checkpoint, resuming scan", {
+          checkpointSession: checkpoint.session_id,
+          currentSession: sessionId,
+          lastCompletedDir: checkpoint.last_completed_dir,
+          savedAt: checkpoint.saved_at,
+          ageHours: Math.round(ageMs / 3_600_000),
+        });
+        resumeFromDir = checkpoint.last_completed_dir;
+      }
     }
   } catch (e) {
     logger.warn("Failed to fetch checkpoint, starting fresh", { error: (e as Error).message });
@@ -498,8 +518,17 @@ async function runScan(providedSessionId?: string) {
     const finalStatus = counters.errors > 0 ? "completed_with_errors" : "completed";
     logger.info("Scan completed", { counters, resumed: !!resumeFromDir, skippedDirs: skippedDirs.length, finalStatus });
     await safeScanProgress(sessionId, finalStatus, counters, undefined, skippedDirs);
-    // Clear checkpoint on successful completion
-    await api.clearCheckpoint().catch(() => {});
+    // Clear checkpoint on successful completion — retry once to prevent stale resume on the next scan
+    try {
+      await api.clearCheckpoint();
+    } catch (e) {
+      logger.warn("Failed to clear checkpoint (retrying once)", { error: (e as Error).message });
+      await api.clearCheckpoint().catch((e2) =>
+        logger.error("Failed to clear checkpoint after retry — next scan may skip directories", {
+          error: (e2 as Error).message,
+        })
+      );
+    }
   } catch (e) {
     lastError = (e as Error).message;
     logger.error("Scan failed with exception", { error: lastError });
@@ -544,8 +573,9 @@ async function processBatch(batch: FileCandidate[], sessionId: string) {
 
   const unchanged = batch.length - changedSet.size - needsThumbnailSet.size;
   if (unchanged > 0) {
+    // Note: files_checked was already incremented in the scanner when each file was yielded.
+    // Do NOT add unchanged here — that would double-count those files in the counter.
     logger.debug(`Skipping ${unchanged}/${batch.length} unchanged files in batch`);
-    counters.files_checked += unchanged;
   }
 
   // Files needing thumbnail retry: generate thumbnail + ingest (but they're otherwise unchanged)

--- a/apps/bridge-agent/src/thumbnailer.ts
+++ b/apps/bridge-agent/src/thumbnailer.ts
@@ -18,7 +18,8 @@ import { logger } from "./logger.js";
 const execFileAsync = promisify(execFile);
 
 const THUMB_MAX_DIM = 800; // px
-const SHARP_TIMEOUT_MS = 60_000; // 60 s — prevents hanging on corrupt/huge files
+const SHARP_TIMEOUT_MS = 60_000; // 60 s per-step timeout — prevents hanging on corrupt/huge files
+const PSD_TOTAL_TIMEOUT_MS = 90_000; // 90 s overall cap for the full PSD pipeline (3 steps × 60 s would exceed the UI's 3-min stale threshold)
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return Promise.race([
@@ -41,16 +42,19 @@ export interface ThumbnailResult {
  */
 async function thumbnailPsd(filePath: string): Promise<ThumbnailResult> {
   try {
-    const img = sharp(filePath, { pages: -1 }).flatten({ background: "#ffffff" });
-    const meta = await withTimeout(img.metadata(), SHARP_TIMEOUT_MS, "psd.metadata");
-    const resized = img.resize(THUMB_MAX_DIM, THUMB_MAX_DIM, { fit: "inside", withoutEnlargement: true });
-    const buffer = await withTimeout(resized.jpeg({ quality: 85 }).toBuffer(), SHARP_TIMEOUT_MS, "psd.toBuffer");
-    const outMeta = await withTimeout(sharp(buffer).metadata(), SHARP_TIMEOUT_MS, "psd.outMeta");
-    return {
-      buffer,
-      width: outMeta.width || meta.width || 0,
-      height: outMeta.height || meta.height || 0,
+    const psdWork = async () => {
+      const img = sharp(filePath, { pages: -1 }).flatten({ background: "#ffffff" });
+      const meta = await withTimeout(img.metadata(), SHARP_TIMEOUT_MS, "psd.metadata");
+      const resized = img.resize(THUMB_MAX_DIM, THUMB_MAX_DIM, { fit: "inside", withoutEnlargement: true });
+      const buffer = await withTimeout(resized.jpeg({ quality: 85 }).toBuffer(), SHARP_TIMEOUT_MS, "psd.toBuffer");
+      const outMeta = await withTimeout(sharp(buffer).metadata(), SHARP_TIMEOUT_MS, "psd.outMeta");
+      return {
+        buffer,
+        width: outMeta.width || meta.width || 0,
+        height: outMeta.height || meta.height || 0,
+      };
     };
+    return await withTimeout(psdWork(), PSD_TOTAL_TIMEOUT_MS, "psd.total");
   } catch (e) {
     logger.warn("Sharp PSD failed", { filePath, error: (e as Error).message });
   }


### PR DESCRIPTION
…date clearing

Five bugs fixed in the bridge agent:

1. api-client.ts: Add 30s AbortSignal.timeout() to every fetch() call in callApi. Without this, a hung network connection blocks the scan indefinitely (no progress updates → UI shows "stuck" after 3 minutes).

2. thumbnailer.ts: Wrap the entire PSD thumbnail pipeline in a single 90s overall timeout (PSD_TOTAL_TIMEOUT_MS). Previously three sequential 60s per-step timeouts could total 180s, reliably tripping the UI's 3-minute stale threshold.

3. index.ts: Fix stale checkpoint causing missing files. clearCheckpoint() was silently swallowed (.catch(()=>{})). Now retries once with explicit error logging. Also added a 12-hour age guard: if a checkpoint is from a different session AND older than 12h, it is discarded (not resumed) so a fresh scan doesn't skip large portions of the directory tree.

4. index.ts / api-client.ts: Fix scan_min_date not clearing when admin removes it. The old guard (if cfg.scanning.scan_min_date) treated null as falsy and never cleared cloudScanMinDate. Changed to !== undefined so null actively resets the filter. Also added scan_min_date to HeartbeatResponse type.

5. index.ts: Remove double-counting of files_checked for unchanged files. files_checked is already incremented per file in the scanner; adding it again for unchanged files in processBatch inflated the counter shown in the UI.

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS