### PR TITLE
Bump bridge agent to v1.1.0; add versioning rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,12 @@ After pushing a feature branch, automatically:
 3. No need to ask for confirmation before merging
 
 Do this without prompting the user for approval.
+
+## Versioning
+
+Whenever changes are made to `apps/bridge-agent/`, bump `apps/bridge-agent/package.json` version as part of the same commit:
+- Patch (x.x.**X**): bug fixes, non-breaking changes
+- Minor (x.**X**.0): new features, behavioral changes
+- Major (**X**.0.0): breaking changes or major rewrites
+
+Always include the version bump in the commit that contains the changes — never in a separate commit.

--- a/apps/bridge-agent/package.json
+++ b/apps/bridge-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popdam-bridge-agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PopDAM Bridge Agent — NAS filesystem scanner, thumbnail generator, and cloud sync worker",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `apps/bridge-agent/package.json` from `1.0.0` → `1.1.0`
- Adds versioning policy to `CLAUDE.md` so future changes always include a version bump

## What's in v1.1.0
All fixes since the initial release:
- Scan stuck / missing files (timeouts, stale checkpoint, scan_min_date)
- Heartbeat timeout (60s heartbeat, 30s others)
- Version display (immediate heartbeat on startup)
- Waiting-for-agent after container rebuild (background registration, orphaned claim re-trigger)
- No-new-assets from stale different-session checkpoint

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS