### PR TITLE
Speed up AI tagging: direct edge calls, smart-skip, unlimited auto-resume

### DIFF
--- a/supabase/functions/bulk-job-runner/index.ts
+++ b/supabase/functions/bulk-job-runner/index.ts
@@ -39,6 +39,7 @@ const LOCAL_HANDLER_OPS = new Set(["rebuild-style-groups"]);
 // Operations that bypass admin-api HTTP and call their edge function directly
 const DIRECT_EDGE_OPS = new Set(["ai-tag-untagged", "ai-tag-all", "ai-tag-groups"]);
 
+
 const AUTO_RESUME_DEFAULTS = {
   enabled: true,
   maxAttempts: 5,
@@ -50,6 +51,11 @@ const AUTO_RESUME_MAX_ATTEMPTS_BY_OP: Record<string, number> = {
   // Long-running ERP classification can hit intermittent gateway timeouts at scale.
   // Allow substantially more resumptions so very large runs (e.g. 90k+) don't stall.
   "erp-classify": 1000,
+  // AI tagging at 81k+ assets will run for many hours; allow unlimited auto-resumes.
+  // Without this, the default limit of 5 causes permanent stall after ~30 minutes.
+  "ai-tag-untagged": 1000,
+  "ai-tag-all": 1000,
+  "ai-tag-groups": 1000,
   // Propagation iterates many groups with heavy per-group queries; transient WORKER_LIMIT is common.
   "propagate-group-tags": 50,
   // Rebuild processes 90k+ assets across 4 stages; rate limits and timeouts are expected.


### PR DESCRIPTION
## Summary
- **Direct edge calls**: `bulk-job-runner` now calls `ai-tag` directly, bypassing the `admin-api` hop that was hitting Supabase's 60s edge function timeout and generating 502/503/504 gateway errors
- **Smart-skip**: for `ai-tag-untagged`, pre-fetches style groups that already have a tagged representative and excludes them — avoids redundant work and correctly advances the cursor
- **Priority ordering**: processes tech_pack > mockup > generic > art > packaging (via `primary_sort_tier`) so highest-value assets are tagged first
- **Unlimited auto-resume**: raises `maxAttempts` to 1000 for all ai-tag ops — the old default of 5 caused permanent stall after ~30 min on an 81k-asset corpus

**Before**: ~4 assets/min → 308hr ETA for 81k assets  
**Expected after**: ~24+ assets/min → <60hr ETA

## Test plan
- [ ] Start "Tag Untagged" from the AI tagging UI
- [ ] Confirm throughput > 4 assets/min in the progress display
- [ ] Confirm no 502/503/504 errors in Supabase function logs
- [ ] Let run for >30 min to confirm auto-resume continues past old 5-attempt limit

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS