### PR TITLE
Improve AI tagging orchestration: concurrency 4, self-continue, no delay

### DIFF
--- a/supabase/functions/bulk-job-runner/index.ts
+++ b/supabase/functions/bulk-job-runner/index.ts
@@ -27,9 +27,9 @@ const INTER_CALL_DELAY_MS: Record<string, number> = {
   "reconcile-style-group-stats": 100, // Now runs via DB function — minimal delay needed
   "erp-classify": 1000, // 5 AI calls per batch (~40s), give breathing room between batches
   "propagate-group-tags": 100, // Now runs via DB function — minimal delay needed
-  "ai-tag-untagged": 500,
-  "ai-tag-all": 500,
-  "ai-tag-groups": 500,
+  "ai-tag-untagged": 0, // Direct edge path — no admin-api rate limit to respect
+  "ai-tag-all": 0,
+  "ai-tag-groups": 0,
 };
 
 // Operations that bypass admin-api HTTP and call db.rpc() directly
@@ -602,8 +602,8 @@ serve(async (req: Request) => {
             break;
           }
         } else if (DIRECT_EDGE_OPS.has(opKey)) {
-          // ── Direct Edge Function path (single 2-wide chunk, smart-skip) ──────
-          const AI_TAG_CONCURRENCY = 2;
+          // ── Direct Edge Function path (smart-skip, 4-wide concurrency) ──────
+          const AI_TAG_CONCURRENCY = 4;
           const AI_TAG_REQUEST_TIMEOUT_MS = 25_000;
           const force = opKey === "ai-tag-all" || opKey === "ai-tag-groups";
           const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || serviceRoleKey;
@@ -1110,6 +1110,21 @@ serve(async (req: Request) => {
       }
 
       await db.rpc("update_bulk_operations_batch", { p_updates: finalUpdates });
+    }
+
+    // Self-continue: when the time budget is exhausted with work still remaining, immediately
+    // fire the next invocation so there's no ~15s idle gap waiting for the next pg_cron tick.
+    // The per-op atomic lock (p_only_if_status:"running") prevents double-processing if pg_cron
+    // also fires during the overlap.
+    if (!done && !lastError) {
+      const selfFetch = fetch(`${supabaseUrl}/functions/v1/bulk-job-runner`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${serviceRoleKey}`, "Content-Type": "application/json" },
+        body: "{}",
+      }).catch(() => {});
+      if (typeof (globalThis as any).EdgeRuntime !== "undefined") {
+        (globalThis as any).EdgeRuntime.waitUntil(selfFetch);
+      }
     }
 
     return json({


### PR DESCRIPTION
## Summary
- **Concurrency 2 → 4**: each round tags 4 assets in parallel instead of 2. Safe because `bulk-job-runner` calls `ai-tag` directly (each call has its own independent 25s timeout, no shared wall clock)
- **Self-continue**: after each time-sliced invocation, fire-and-forget a POST to itself via `EdgeRuntime.waitUntil()` so the next run starts immediately — eliminates the ~15s idle gap waiting for the next pg_cron tick
- **Zero inter-call delay for ai-tag ops**: the 500ms delay existed to avoid admin-api rate limits, which no longer apply on the direct edge path

## Expected impact

| | Before | After |
|---|---|---|
| Concurrency | 2 | 4 |
| Idle gap/min | ~15s | ~0s |
| Inter-call delay | 500ms | 0ms |
| Throughput | ~4 assets/min | ~10–15 assets/min |
| ETA (81k assets) | ~308 hrs | ~90–135 hrs |

## Test plan
- [ ] Start "Tag Untagged" from AI Tagging UI
- [ ] Confirm throughput >8 assets/min within 5 minutes
- [ ] Check Supabase function logs — no runaway self-continue chains, no 502/503/504 errors
- [ ] After 30+ min confirm auto-resume has not stalled

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS