### PR TITLE
Fix invitation emails: switch from Brevo to Supabase Auth invites

### DIFF
--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -349,21 +349,19 @@ async function handleInviteUser(
 
   if (error) return err(error.message, 500);
 
-  // Fire-and-forget invite email
-  try {
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    await fetch(`${supabaseUrl}/functions/v1/send-invite-email`, {
-      signal: AbortSignal.timeout(10_000),
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${serviceKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ email, invitation_id: data.id }),
-    });
-  } catch (e) {
-    console.error("Failed to trigger invite email:", e);
+  // Send invite via Supabase Auth — no external email service required
+  const adminClient = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+  const { error: inviteErr } = await adminClient.auth.admin.inviteUserByEmail(email, {
+    data: { role: roleStr },
+  });
+  if (inviteErr) {
+    // Roll back the invitation row so the admin can retry
+    await db.from("invitations").delete().eq("id", data.id);
+    return err(`Failed to send invitation email: ${inviteErr.message}`, 500);
   }
 
   return json({ ok: true, invitation: data });
@@ -390,7 +388,7 @@ async function handleRevokeInvite(body: Record<string, unknown>) {
 
   const { data: invite } = await db
     .from("invitations")
-    .select("accepted_at")
+    .select("email, accepted_at")
     .eq("id", invitationId)
     .single();
 
@@ -405,6 +403,22 @@ async function handleRevokeInvite(body: Record<string, unknown>) {
     .eq("id", invitationId);
 
   if (error) return err(error.message, 500);
+
+  // Also delete the pending auth user so they can't sign in with the invite link
+  const adminClient = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+  const { data: profile } = await db
+    .from("profiles")
+    .select("user_id")
+    .eq("email", invite.email)
+    .maybeSingle();
+  if (profile?.user_id) {
+    await adminClient.auth.admin.deleteUser(profile.user_id).catch(() => {});
+  }
+
   return json({ ok: true });
 }
 

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders, json } from "../_shared/http.ts";
 
 serve(async (req: Request) => {
@@ -7,61 +8,24 @@ serve(async (req: Request) => {
   }
 
   try {
-    const BREVO_API_KEY = Deno.env.get("BREVO_API_KEY");
-    if (!BREVO_API_KEY) {
-      console.warn("BREVO_API_KEY not configured — skipping email send");
-      return json({ ok: true, skipped: true, reason: "BREVO_API_KEY not configured" });
-    }
-
-    const { email, invitation_id } = await req.json();
+    const { email } = await req.json();
     if (!email) {
       return json({ ok: false, error: "email is required" }, 400);
     }
 
-    // Build a simple HTML invitation email
-    const appUrl = Deno.env.get("POPDAM_APP_URL") || "https://dam.designflow.app";
-    const subject = "You've been invited to PopDAM";
-    const htmlContent = `
-      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 500px; margin: 0 auto; padding: 32px; background: #1a1d23; color: #e4e4e7; border-radius: 12px;">
-        <h1 style="color: #f59e0b; font-size: 24px; margin-bottom: 16px;">Welcome to PopDAM</h1>
-        <p style="line-height: 1.6; margin-bottom: 24px;">
-          You've been invited to join PopDAM — the Digital Asset Manager for licensed character design files.
-        </p>
-        <p style="line-height: 1.6; margin-bottom: 24px;">
-          Click the button below to create your account and get started.
-        </p>
-        <div style="text-align: center; margin: 32px 0;">
-          <a href="${appUrl}" style="display: inline-block; background: #f59e0b; color: #1a1d23; padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px;">
-            Accept Invitation
-          </a>
-        </div>
-        <p style="font-size: 12px; color: #71717a; margin-top: 32px;">
-          If you didn't expect this invitation, you can safely ignore this email.
-        </p>
-      </div>
-    `;
-
-    const brevoResponse = await fetch("https://api.brevo.com/v3/smtp/email", {
-      method: "POST",
-      headers: {
-        "api-key": BREVO_API_KEY,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        sender: { name: "PopDAM", email: "noreply@popdam.com" },
-        to: [{ email }],
-        subject,
-        htmlContent,
-      }),
-    });
-
-    if (!brevoResponse.ok) {
-      const errorText = await brevoResponse.text();
-      console.error("Brevo send failed:", brevoResponse.status, errorText);
-      return json({ ok: false, error: "Email send failed" }, 500);
+    // Re-send invite using Supabase Auth — no external email service required.
+    // inviteUserByEmail re-sends the magic link for a pending (not-yet-confirmed) user.
+    const adminClient = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+    const { error } = await adminClient.auth.admin.inviteUserByEmail(email);
+    if (error) {
+      console.error("Re-invite failed:", error.message);
+      return json({ ok: false, error: error.message }, 500);
     }
 
-    await brevoResponse.text(); // consume body
     return json({ ok: true, sent: true });
   } catch (e) {
     console.error("send-invite-email error:", e);

--- a/supabase/migrations/20260320162636_fix-invitation-trigger.sql
+++ b/supabase/migrations/20260320162636_fix-invitation-trigger.sql
@@ -1,0 +1,72 @@
+-- Fix invitation trigger to preserve Pending/Accepted semantics when using
+-- auth.admin.inviteUserByEmail(), which inserts into auth.users immediately
+-- (with invited_at set, email_confirmed_at null) before the user clicks the link.
+--
+-- Before: handle_new_user set accepted_at on INSERT, so all invites showed "Accepted" immediately.
+-- After:
+--   handle_new_user creates profile + assigns role but does NOT set accepted_at for admin invites.
+--   handle_user_confirmed sets accepted_at when the user actually clicks the magic link.
+
+-- 1. Update handle_new_user to skip accepted_at for admin-invited (not-yet-confirmed) users
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  _invitation record;
+  _email text;
+BEGIN
+  _email := NEW.email;
+
+  SELECT * INTO _invitation
+  FROM public.invitations
+  WHERE email = _email AND accepted_at IS NULL;
+
+  IF _invitation IS NULL THEN
+    RAISE EXCEPTION 'Access denied: no valid invitation found for %', _email;
+  END IF;
+
+  -- Create profile
+  INSERT INTO public.profiles (user_id, email, full_name)
+  VALUES (NEW.id, _email, COALESCE(NEW.raw_user_meta_data->>'full_name', _email));
+
+  -- Assign role from invitation
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, _invitation.role);
+
+  -- Only mark accepted when this is a regular signup (user confirmed themselves).
+  -- For admin invites (invited_at set, email not yet confirmed), leave accepted_at null
+  -- so the invitation shows as "Pending" until the user clicks the magic link.
+  IF NEW.invited_at IS NULL OR NEW.email_confirmed_at IS NOT NULL THEN
+    UPDATE public.invitations
+    SET accepted_at = now()
+    WHERE id = _invitation.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 2. Add trigger to mark invitation accepted when user confirms their email (clicks magic link)
+CREATE OR REPLACE FUNCTION public.handle_user_confirmed()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.email_confirmed_at IS NULL AND NEW.email_confirmed_at IS NOT NULL THEN
+    UPDATE public.invitations
+    SET accepted_at = now()
+    WHERE email = NEW.email AND accepted_at IS NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_email_confirmed
+  AFTER UPDATE OF email_confirmed_at ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_user_confirmed();


### PR DESCRIPTION
## Problem
Invitation emails were never going out. The `BREVO_API_KEY` secret was not configured, and `send-invite-email` silently returned `{ok: true, skipped: true}` without any visible error to the admin.

## Fix
Replace Brevo entirely with Supabase's built-in `auth.admin.inviteUserByEmail()`, which uses the project's own email relay — no external API key needed.

## Changes
- **`admin-api` `handleInviteUser`**: calls `auth.admin.inviteUserByEmail()` after inserting the invitation row; errors are now surfaced to the UI; rolls back the invitation row on failure so the admin can retry
- **`admin-api` `handleRevokeInvite`**: also deletes the pending auth user so they can't sign in after revocation
- **`send-invite-email`**: replaces Brevo with `inviteUserByEmail` for the Resend button
- **Migration**: updates `handle_new_user` trigger to preserve Pending/Accepted semantics — does not set `accepted_at` for admin-invited users until they click the link; adds `handle_user_confirmed` trigger that sets `accepted_at` when `email_confirmed_at` is populated

## Test plan
- [ ] Invite a new email → confirm Supabase invitation email arrives (magic link)
- [ ] Confirm invite shows as **Pending** in the UI until the link is clicked
- [ ] Click magic link → confirm profile created, role assigned, invite shows as **Accepted**
- [ ] Test **Revoke** before acceptance → confirm auth user deleted, invite gone
- [ ] Test **Resend** button → confirm new magic link email arrives

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS