### PR TITLE
Add prepack fields, fix ERP Items Browser and dry run output

### DIFF
--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -503,6 +503,15 @@ function EnrichmentControls() {
                   {dryRunResult.sample_updates.map((row: any, idx: number) => (
                     <div key={`${row.external_id}-${idx}`} className="rounded border border-border/60 bg-background/60 p-2 text-[11px] font-mono">
                       <div>SKU: <span className="text-foreground">{row.sku}</span> · ERP ID: <span className="text-foreground">{row.external_id}</span></div>
+                      {row.description && <div className="text-muted-foreground truncate">Desc: <span className="text-foreground">{row.description}</span></div>}
+                      <div>
+                        AI category: <span className="text-foreground font-semibold">{row.predicted_category ?? "—"}</span>
+                        {row.prediction_status && row.prediction_status !== "erp" && (
+                          <span className={`ml-1.5 ${row.prediction_status === "pending" ? "text-yellow-500" : row.prediction_status === "auto_applied" ? "text-green-500" : "text-muted-foreground"}`}>
+                            [{row.prediction_status}]
+                          </span>
+                        )}
+                      </div>
                       <div>Matches → assets: <span className="text-foreground">{row.matching_asset_count ?? 0}</span>, groups: <span className="text-foreground">{row.matching_group_count ?? 0}</span></div>
                       <div>Source: <span className="text-foreground">{row.classification_source}</span> · Confidence: <span className="text-foreground">{typeof row.confidence === "number" ? `${Math.round(row.confidence * 100)}%` : "—"}</span></div>
                       <pre className="mt-1 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">{JSON.stringify(row.proposed_fields ?? {}, null, 2)}</pre>

--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -1060,6 +1060,8 @@ function ErpItemsBrowser() {
     { key: "licensor_code", label: "Licensor" },
     { key: "property_code", label: "Property" },
     { key: "division_code", label: "Division" },
+    { key: "prepack_code", label: "Prepack" },
+    { key: "prepack_codes", label: "Prepack Codes" },
   ];
 
   return (
@@ -1258,6 +1260,8 @@ function ErpItemsBrowser() {
                                     </TooltipContent>
                                   </Tooltip>
                                 </TooltipProvider>
+                              ) : col.key === "prepack_codes" && Array.isArray(item[col.key]) ? (
+                                <span className="text-foreground">{(item[col.key] as string[]).join(", ")}</span>
                               ) : item[col.key] ? (
                                 <span className="text-foreground">{item[col.key]}</span>
                               ) : (

--- a/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
@@ -331,7 +331,7 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
     const countSql = `SELECT count(*)::int as cnt FROM erp_items_current ${whereClause}`;
     const dataSql =
-      `SELECT id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code, erp_updated_at, synced_at, raw_mg_fields, external_id, dismissed FROM erp_items_current ${whereClause} ORDER BY ${effectiveSort} ${
+      `SELECT id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code, prepack_code, prepack_codes, erp_updated_at, synced_at, raw_mg_fields, external_id, dismissed FROM erp_items_current ${whereClause} ORDER BY ${effectiveSort} ${
         sortAsc ? "ASC" : "DESC"
       } NULLS LAST LIMIT ${pageSize} OFFSET ${offset}`;
 
@@ -362,7 +362,7 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
 
   let dataQuery = db.from("erp_items_current")
     .select(
-      "id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, mg04_code, mg05_code, mg06_code, size_code, licensor_code, property_code, division_code, erp_updated_at, synced_at, raw_mg_fields, dismissed",
+      "id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, mg04_code, mg05_code, mg06_code, size_code, licensor_code, property_code, division_code, prepack_code, prepack_codes, erp_updated_at, synced_at, raw_mg_fields, dismissed",
     )
     .order(effectiveSort, { ascending: sortAsc, nullsFirst: false })
     .range(offset, offset + pageSize - 1);

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -17,7 +17,7 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
   // Fetch ERP items that have MG category fields
   const { data: erpItems, error: erpErr } = await db
     .from("erp_items_current")
-    .select("id, external_id, style_number, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code")
+    .select("id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code")
     .not("style_number", "is", null)
     .neq("style_number", "")
     .order("external_id")
@@ -37,6 +37,7 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
     id: string;
     external_id: string;
     style_number: string | null;
+    item_description: string | null;
     mg_category: string | null;
     mg01_code: string | null;
     mg02_code: string | null;
@@ -45,11 +46,13 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
     licensor_code: string | null;
     property_code: string | null;
     division_code: string | null;
-  }): Promise<{ updates: Record<string, unknown>; classification_source: string; confidence: number }> {
+  }): Promise<{ updates: Record<string, unknown>; classification_source: string; confidence: number; predicted_category: string | null; prediction_status: string | null }> {
     const updates: Record<string, unknown> = {};
     let classificationSource = "erp";
     let confidence = 1.0;
     let productCategory: string | null = null;
+    let predictedCategory: string | null = null;
+    let predictionStatus: string | null = null;
 
     // Try AI prediction if no ERP category
     if (!erpItem.mg_category) {
@@ -57,15 +60,22 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
         .from("product_category_predictions")
         .select("predicted_category, confidence, classification_source, status")
         .eq("erp_item_id", erpItem.id)
+        .order("created_at", { ascending: false })
         .maybeSingle();
 
-      if (predictionRow && ["approved", "auto_applied"].includes(predictionRow.status)) {
-        productCategory = predictionRow.predicted_category;
-        classificationSource = predictionRow.classification_source || "ai";
-        confidence = predictionRow.confidence ?? 0.8;
+      if (predictionRow) {
+        predictedCategory = predictionRow.predicted_category;
+        predictionStatus = predictionRow.status;
+        if (["approved", "auto_applied"].includes(predictionRow.status)) {
+          productCategory = predictionRow.predicted_category;
+          classificationSource = predictionRow.classification_source || "ai";
+          confidence = predictionRow.confidence ?? 0.8;
+        }
       }
     } else {
       productCategory = erpItem.mg_category;
+      predictedCategory = erpItem.mg_category;
+      predictionStatus = "erp";
     }
 
     // Apply ERP fields
@@ -82,6 +92,8 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
       updates,
       classification_source: classificationSource,
       confidence,
+      predicted_category: predictedCategory,
+      prediction_status: predictionStatus,
     };
   }
 
@@ -128,14 +140,17 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
     const sample_updates: Array<Record<string, unknown>> = [];
     for (const erpItem of erpItems.slice(0, 20)) {
       if (!erpItem.style_number) continue;
-      const { updates, classification_source, confidence } = await buildProposedUpdates(erpItem);
-      if (Object.keys(updates).length === 0) continue;
+      const { updates, classification_source, confidence, predicted_category, prediction_status } = await buildProposedUpdates(erpItem);
+      if (Object.keys(updates).length === 0 && !predicted_category) continue;
 
       sample_updates.push({
         external_id: erpItem.external_id,
         sku: erpItem.style_number,
+        description: erpItem.item_description ?? null,
         classification_source,
         confidence,
+        predicted_category,
+        prediction_status,
         proposed_fields: updates,
         matching_asset_count: assetCountBySku.get(erpItem.style_number) ?? 0,
         matching_group_count: groupCountBySku.get(erpItem.style_number) ?? 0,

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -17,7 +17,9 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
   // Fetch ERP items that have MG category fields
   const { data: erpItems, error: erpErr } = await db
     .from("erp_items_current")
-    .select("id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code")
+    .select(
+      "id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code",
+    )
     .not("style_number", "is", null)
     .neq("style_number", "")
     .order("external_id")
@@ -46,7 +48,9 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
     licensor_code: string | null;
     property_code: string | null;
     division_code: string | null;
-  }): Promise<{ updates: Record<string, unknown>; classification_source: string; confidence: number; predicted_category: string | null; prediction_status: string | null }> {
+  }): Promise<
+    { updates: Record<string, unknown>; classification_source: string; confidence: number; predicted_category: string | null; prediction_status: string | null }
+  > {
     const updates: Record<string, unknown> = {};
     let classificationSource = "erp";
     let confidence = 1.0;

--- a/supabase/functions/erp-sync/index.ts
+++ b/supabase/functions/erp-sync/index.ts
@@ -238,6 +238,8 @@ serve(async (req: Request) => {
             licensor_code: item.licensor || item.licensorCode || null,
             property_code: item.property || item.propertyCode || null,
             division_code: item.divisionCode || null,
+            prepack_code: item.prepackCode || null,
+            prepack_codes: Array.isArray(item.prepackCodes) && item.prepackCodes.length > 0 ? item.prepackCodes : null,
             erp_updated_at: erpDate,
             sync_run_id: runId,
             synced_at: new Date().toISOString(),

--- a/supabase/migrations/20260322120000_add-prepack-fields-to-erp-items.sql
+++ b/supabase/migrations/20260322120000_add-prepack-fields-to-erp-items.sql
@@ -1,0 +1,4 @@
+-- Add prepack_code and prepack_codes fields to erp_items_current
+ALTER TABLE erp_items_current
+  ADD COLUMN IF NOT EXISTS prepack_code text,
+  ADD COLUMN IF NOT EXISTS prepack_codes jsonb;


### PR DESCRIPTION
## Summary
- Adds `prepack_code` and `prepack_codes` fields to ERP sync and `erp_items_current` table (migration applied to prod)
- Fixes ERP Items Browser being empty after full sync (migration was unapplied, causing upsert failures)
- Adds Prepack / Prepack Codes columns to the ERP Items Browser table
- Dry run now shows item description and what Haiku classified (including pending predictions, not just approved ones)

## Test plan
- [ ] Run a full ERP sync — browser should populate
- [ ] Items with prepack data show non-empty Prepack / Prepack Codes columns
- [ ] Dry run output shows description + AI category with pending/auto_applied status

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS