### PR TITLE
fix(worker): yield after MAX_BATCHES_PER_TICK to time-share between concurrent ops

### DIFF
--- a/apps/worker/src/operation-loop.ts
+++ b/apps/worker/src/operation-loop.ts
@@ -23,6 +23,8 @@ import { handleApplyErpEnrichment, handleClassifyErpCategories } from "./handler
 const CONFIG_KEY = "BULK_OPERATIONS";
 const STALE_RUN_MINUTES = 10;
 const INTERRUPT_CHECK_EVERY = 10;
+/** Yield after this many batches so the round-robin can serve other operations */
+const MAX_BATCHES_PER_TICK = 5;
 
 // Lane isolation — operations in the same lane are mutually exclusive
 const OP_LANES: Record<string, string> = {
@@ -352,6 +354,12 @@ export async function tick(): Promise<void> {
         updated_at: new Date().toISOString(),
       });
       return;
+    }
+
+    // Yield after MAX_BATCHES_PER_TICK so other operations get a turn
+    if (batchCount >= MAX_BATCHES_PER_TICK) {
+      logger.info("tick: yielding after max batches", { opKey, batches: batchCount, cursor });
+      return; // State already saved above; main loop re-enters tick()
     }
   }
 }

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -35,23 +35,33 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
   let erpErr: { message: string } | null = null;
 
   if (mode === "dry-run") {
-    // Pull ERP items whose SKU exists in assets or style_groups (limit 50 for the sample)
-    const { data, error } = await db.rpc("execute_readonly_query", {
-      query_text: `
-        SELECT e.id, e.external_id, e.style_number, e.item_description,
-               e.mg_category, e.mg01_code, e.mg02_code, e.mg03_code,
-               e.size_code, e.licensor_code, e.property_code, e.division_code
-        FROM erp_items_current e
-        WHERE e.style_number IS NOT NULL AND e.style_number <> ''
-          AND EXISTS (
-            SELECT 1 FROM assets a WHERE a.sku = e.style_number AND a.is_deleted = false
-          )
-        ORDER BY e.mg_category NULLS LAST, e.external_id
-        LIMIT 50
-      `,
-    });
-    erpItems = (data as typeof erpItems) ?? null;
-    erpErr = error ? { message: error.message } : null;
+    // Fetch a candidate batch of ERP items (mg_category first), then filter to those
+    // that have a matching asset SKU — avoids execute_readonly_query RPC restrictions.
+    const { data: candidates, error: candidateErr } = await db
+      .from("erp_items_current")
+      .select(
+        "id, external_id, style_number, item_description, mg_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code",
+      )
+      .not("style_number", "is", null)
+      .neq("style_number", "")
+      .order("mg_category", { ascending: true, nullsFirst: false })
+      .order("external_id", { ascending: true })
+      .limit(300);
+
+    if (candidateErr) {
+      erpItems = null;
+      erpErr = { message: candidateErr.message };
+    } else {
+      const candidateSkus = (candidates ?? []).map((c) => c.style_number).filter(Boolean) as string[];
+      const { data: matchedAssets } = await db
+        .from("assets")
+        .select("sku")
+        .in("sku", candidateSkus.length > 0 ? candidateSkus : ["__none__"])
+        .eq("is_deleted", false);
+      const matchedSkuSet = new Set((matchedAssets ?? []).map((a) => a.sku).filter(Boolean));
+      erpItems = (candidates ?? []).filter((c) => c.style_number && matchedSkuSet.has(c.style_number)).slice(0, 50);
+      erpErr = null;
+    }
   } else {
     const { data, error } = await db
       .from("erp_items_current")


### PR DESCRIPTION
## Summary
- The worker's inner `while(true)` loop ran one operation to completion before touching any other
- `ai-tag-untagged` (18k/79k assets done) was monopolizing the worker, leaving `erp-enrichment` stuck at cursor 0 indefinitely
- Added `MAX_BATCHES_PER_TICK = 5`: worker yields after 5 batches and the outer polling loop re-enters `tick()`, where the round-robin (least-recently-updated) picks the next operation

## Fix
`apps/worker/src/operation-loop.ts` — added yield after `MAX_BATCHES_PER_TICK` batches in the inner processing loop.

Also refreshed `erp-enrichment.updated_at` directly in the DB to prevent stale-lock detection from marking it as interrupted before the worker can pick it up.

## Test plan
- [ ] Railway redeploys with this fix
- [ ] Both `erp-enrichment` and `ai-tag-untagged` show `updated_at` advancing in `admin_config`
- [ ] Apply Enrichment shows progress in the UI within ~30 seconds of deploy

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS