### PR TITLE
fix: cover_description backfill and trailing inch mark cleanup

### DIFF
--- a/apps/worker/src/handlers/erp.ts
+++ b/apps/worker/src/handlers/erp.ts
@@ -25,7 +25,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   let s = itemDescription.replace(/_/g, " ");
   // Strip dimension patterns: 23.5x10" x15.5", 10x15, etc.
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -12,7 +12,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   if (!itemDescription?.trim()) return null;
   let s = itemDescription.replace(/_/g, " ");
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 


### PR DESCRIPTION
## Summary

- **Data backfill**: Ran SQL to populate `cover_description` on all `assets` (and via trigger, `style_groups`) where it was NULL, deriving it from ERP `item_description` — strips dimension patterns and underscores. Fixes items like PJG4DDYCP01 that had an ERP description visible in the detail panel but nothing on the card cover.
- **Hardened trim**: `deriveErpCoverDescription` now also strips leading/trailing inch/quote marks (`"″`) in the final trim pass, preventing a trailing `"` when a dimension ends with an inch symbol at the end of the string.

## Test plan

- [ ] PJG4DDYCP01 card now shows "Disney Aristocats Fabric Grayboard Jewelry Box with Embroidery Marie Heart" on the cover
- [ ] No items should have a `cover_description` ending in `"` or `″`
- [ ] Re-running Apply ERP Enrichment should not overwrite existing cover_description values (IS NULL guard is unchanged)

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS