### PR TITLE
fix: ERP cover_description always overwrites AI-tagged values

### DIFF
--- a/apps/worker/src/handlers/erp.ts
+++ b/apps/worker/src/handlers/erp.ts
@@ -25,7 +25,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   let s = itemDescription.replace(/_/g, " ");
   // Strip dimension patterns: 23.5x10" x15.5", 10x15, etc.
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 

--- a/apps/worker/src/handlers/erp.ts
+++ b/apps/worker/src/handlers/erp.ts
@@ -98,8 +98,8 @@ export async function handleApplyErpEnrichment(opState: OpState): Promise<BatchR
         .select("id");
       groupsUpdated += groupRows?.length ?? 0;
 
-      // Populate cover_description on untagged assets from ERP item_description.
-      // Only writes where cover_description IS NULL so AI-tagged values are never overwritten.
+      // Populate cover_description on assets from ERP item_description.
+      // ERP always takes precedence — overwrites AI-tagged values.
       // The sync_cover_description_to_style_group trigger propagates it to style_groups.
       const coverDesc = deriveErpCoverDescription(erpItem.item_description ?? null);
       if (coverDesc) {
@@ -107,8 +107,7 @@ export async function handleApplyErpEnrichment(opState: OpState): Promise<BatchR
           .from("assets")
           .update({ cover_description: coverDesc })
           .eq("sku", erpItem.style_number)
-          .eq("is_deleted", false)
-          .is("cover_description", null);
+          .eq("is_deleted", false);
       }
     }
   }

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -268,16 +268,15 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
       .select("id");
     groupsUpdated += groupRows?.length ?? 0;
 
-    // Populate cover_description on untagged assets from ERP item_description.
-    // Only writes where cover_description IS NULL so AI-tagged values are never overwritten.
+    // Populate cover_description on assets from ERP item_description.
+    // ERP always takes precedence — overwrites AI-tagged values.
     // The sync_cover_description_to_style_group trigger propagates it to style_groups.
     const coverDesc = deriveErpCoverDescription(erpItem.item_description ?? null);
     if (coverDesc) {
       await db.from("assets")
         .update({ cover_description: coverDesc })
         .eq("sku", erpItem.style_number)
-        .eq("is_deleted", false)
-        .is("cover_description", null);
+        .eq("is_deleted", false);
     }
   }
 

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -12,7 +12,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   if (!itemDescription?.trim()) return null;
   let s = itemDescription.replace(/_/g, " ");
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 


### PR DESCRIPTION
## Summary
- ERP enrichment previously only set `cover_description` where the field was NULL, leaving incorrect AI-tagged values (e.g. "packaging" on a mockup file) permanently in place
- ERP data is the authoritative source of truth for product labels — removed the `.is("cover_description", null)` guard in both the worker handler and the edge function handler so ERP always wins

## Root cause
When an asset is AI-tagged before ERP enrichment runs (common on ingest), the AI has no ERP context and infers from the image. A mockup image shows the product in retail packaging, so the AI calls it "packaging." Once tagged, the old code would never correct it.

## Test plan
- [ ] Run ERP enrichment (`apply-erp-enrichment`) and confirm assets with ERP-matched SKUs have their `cover_description` updated even when previously AI-tagged
- [ ] Verify `CA028DYHM01` assets now show "MDF Plaque" (from ERP) instead of "packaging"
- [ ] Confirm style group `cover_description` updates via the existing trigger

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS