### PR TITLE
feat: show cover_description in Apply Enrichment live log

### DIFF
--- a/apps/worker/src/handlers/erp.ts
+++ b/apps/worker/src/handlers/erp.ts
@@ -25,7 +25,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   let s = itemDescription.replace(/_/g, " ");
   // Strip dimension patterns: 23.5x10" x15.5", 10x15, etc.
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 

--- a/apps/worker/src/handlers/erp.ts
+++ b/apps/worker/src/handlers/erp.ts
@@ -98,8 +98,8 @@ export async function handleApplyErpEnrichment(opState: OpState): Promise<BatchR
         .select("id");
       groupsUpdated += groupRows?.length ?? 0;
 
-      // Populate cover_description on untagged assets from ERP item_description.
-      // Only writes where cover_description IS NULL so AI-tagged values are never overwritten.
+      // Populate cover_description on assets from ERP item_description.
+      // ERP always takes precedence — overwrites AI-tagged values.
       // The sync_cover_description_to_style_group trigger propagates it to style_groups.
       const coverDesc = deriveErpCoverDescription(erpItem.item_description ?? null);
       if (coverDesc) {
@@ -107,8 +107,7 @@ export async function handleApplyErpEnrichment(opState: OpState): Promise<BatchR
           .from("assets")
           .update({ cover_description: coverDesc })
           .eq("sku", erpItem.style_number)
-          .eq("is_deleted", false)
-          .is("cover_description", null);
+          .eq("is_deleted", false);
       }
     }
   }

--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -344,6 +344,7 @@ function ClassificationLiveLog({ active }: { active: boolean }) {
 // ── Enrichment Apply Live Log ─────────────────────────────────────────
 
 const ENRICHED_FIELDS: Array<{ key: string; label: string }> = [
+  { key: "cover_description", label: "Description" },
   { key: "product_category", label: "Category" },
   { key: "mg01_code", label: "MG01" },
   { key: "mg02_code", label: "MG02" },
@@ -359,6 +360,7 @@ function EnrichmentApplyLiveLog({ active, startedAt }: { active: boolean; starte
     id: string;
     sku: string | null;
     updated_at: string;
+    cover_description: string | null;
     product_category: string | null;
     mg01_code: string | null;
     mg02_code: string | null;
@@ -377,7 +379,7 @@ function EnrichmentApplyLiveLog({ active, startedAt }: { active: boolean; starte
     const poll = async () => {
       const { data } = await supabase
         .from("assets")
-        .select("id, sku, updated_at, product_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code")
+        .select("id, sku, updated_at, cover_description, product_category, mg01_code, mg02_code, mg03_code, size_code, licensor_code, property_code, division_code")
         .gte("updated_at", startedAt)
         .eq("is_deleted", false)
         .order("updated_at", { ascending: false })

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -268,16 +268,15 @@ export async function handleApplyErpEnrichment(body: Record<string, unknown>) {
       .select("id");
     groupsUpdated += groupRows?.length ?? 0;
 
-    // Populate cover_description on untagged assets from ERP item_description.
-    // Only writes where cover_description IS NULL so AI-tagged values are never overwritten.
+    // Populate cover_description on assets from ERP item_description.
+    // ERP always takes precedence — overwrites AI-tagged values.
     // The sync_cover_description_to_style_group trigger propagates it to style_groups.
     const coverDesc = deriveErpCoverDescription(erpItem.item_description ?? null);
     if (coverDesc) {
       await db.from("assets")
         .update({ cover_description: coverDesc })
         .eq("sku", erpItem.style_number)
-        .eq("is_deleted", false)
-        .is("cover_description", null);
+        .eq("is_deleted", false);
     }
   }
 

--- a/supabase/functions/_shared/admin-handlers/erp-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-handlers.ts
@@ -12,7 +12,7 @@ function deriveErpCoverDescription(itemDescription: string | null): string | nul
   if (!itemDescription?.trim()) return null;
   let s = itemDescription.replace(/_/g, " ");
   s = s.replace(/\b\d+\.?\d*["″]?\s*[xX×]\s*\d+\.?\d*["″]?(?:\s*[xX×]\s*\d+\.?\d*["″]?)*/g, "");
-  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,]+|[\s\-_,]+$/g, "").trim();
+  s = s.replace(/\s+/g, " ").replace(/^[\s\-_,"″]+|[\s\-_,"″]+$/g, "").trim();
   return s || null;
 }
 


### PR DESCRIPTION
## Summary
- Added `cover_description` as the first field in the Apply Enrichment live log
- Since ERP now always overwrites AI-tagged descriptions (previous PR), it's useful to see the description being applied to each SKU in real time

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS