### PR TITLE
fix: remove moduleResolution from path-filters tsconfig

### DIFF
--- a/packages/path-filters/tsconfig.json
+++ b/packages/path-filters/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "CommonJS",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,


### PR DESCRIPTION
## Summary
`ignoreDeprecations` is version-dependent — `"5.0"` only works with TS5, `"6.0"` only works with TS6+, so it kept failing regardless of which value was set.

Root fix: remove `"moduleResolution": "node"` from the tsconfig entirely. TypeScript only emits the deprecation warning when the option is *explicitly* set. Removing it lets it default to the same `node` behaviour silently, with no version dependency and no need for `ignoreDeprecations`.

Once merged, CI will pass, publish a new `windows-agent-latest` to `popdam3`, and update `WINDOWS_LATEST_BUILD` in the DB with correct URLs from code — no more manual DB patches needed.

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS