### PR TITLE
feat: add PopDAM Helper — lightweight folder-opener for Windows and Mac

### DIFF
--- a/.github/workflows/publish-popdam-helper.yml
+++ b/.github/workflows/publish-popdam-helper.yml
@@ -1,0 +1,117 @@
+name: Publish PopDAM Helper
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/popdam-helper/**"
+      - ".github/workflows/publish-popdam-helper.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Windows — Node.js + pkg ───────────────────────────────────────
+  build-windows:
+    name: Build Windows helper
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: apps/popdam-helper
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Package with pkg
+        run: npx pkg dist/index.js --target node18-win-x64 --output popdam-helper.exe
+
+      - name: Verify exe exists
+        shell: powershell
+        run: |
+          if (!(Test-Path 'popdam-helper.exe')) {
+            Write-Error 'popdam-helper.exe not found'
+            exit 1
+          }
+          Write-Host "popdam-helper.exe built successfully"
+
+      - name: Create Install.bat
+        shell: powershell
+        run: |
+          $bat = @'
+          @echo off
+          echo Installing PopDAM Helper...
+          "%~dp0popdam-helper.exe" --register
+          if %errorlevel% neq 0 (
+            echo Registration failed. Try running as Administrator.
+            pause
+            exit /b 1
+          )
+          echo.
+          echo Done! The popdam:// protocol is registered.
+          echo You can now use "Open Containing Folder" in the PopDAM web app.
+          pause
+          '@
+          Set-Content -Path Install.bat -Value $bat -Encoding ASCII
+
+      - name: Zip release
+        shell: powershell
+        run: |
+          Compress-Archive -Path popdam-helper.exe, Install.bat -DestinationPath popdam-helper-windows-x64.zip
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: popdam-helper-latest
+          name: PopDAM Helper (latest)
+          body: |
+            Lightweight protocol handler for the PopDAM web app.
+            Handles `popdam://` URLs to open NAS folders in Explorer (Windows) or Finder (Mac).
+
+            **Windows**: unzip, run `Install.bat` once.
+            **Mac**: unzip, move `.app` to Applications, open it once.
+          files: apps/popdam-helper/popdam-helper-windows-x64.zip
+          prerelease: false
+
+  # ── Mac — Swift ───────────────────────────────────────────────────
+  build-mac:
+    name: Build Mac helper
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: apps/popdam-helper
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compile Swift binary
+        run: |
+          swiftc -framework Cocoa platform/mac/main.swift -o "PopDAM Helper"
+
+      - name: Assemble .app bundle
+        run: |
+          mkdir -p "PopDAM Helper.app/Contents/MacOS"
+          cp "PopDAM Helper" "PopDAM Helper.app/Contents/MacOS/"
+          cp platform/mac/Info.plist "PopDAM Helper.app/Contents/"
+
+      - name: Zip release
+        run: |
+          zip -r popdam-helper-mac.zip "PopDAM Helper.app"
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: popdam-helper-latest
+          name: PopDAM Helper (latest)
+          files: apps/popdam-helper/popdam-helper-mac.zip
+          prerelease: false

--- a/apps/popdam-helper/package.json
+++ b/apps/popdam-helper/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "popdam-helper",
+  "version": "1.0.0",
+  "description": "PopDAM local protocol handler — opens NAS folders in Explorer/Finder from the web app",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "pkg": "pkg dist/index.js --target node18-win-x64 --output popdam-helper.exe"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "pkg": "^5.8.1",
+    "typescript": "^5.0.0"
+  },
+  "pkg": {
+    "assets": [],
+    "targets": ["node18-win-x64"]
+  }
+}

--- a/apps/popdam-helper/platform/mac/Info.plist
+++ b/apps/popdam-helper/platform/mac/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.popdam.helper</string>
+    <key>CFBundleName</key>
+    <string>PopDAM Helper</string>
+    <key>CFBundleExecutable</key>
+    <string>PopDAM Helper</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <!-- Background-only app: no Dock icon, no menu bar -->
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <!-- Register the popdam:// URL scheme -->
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>PopDAM Folder Opener</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>popdam</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/apps/popdam-helper/platform/mac/main.swift
+++ b/apps/popdam-helper/platform/mac/main.swift
@@ -1,0 +1,66 @@
+// PopDAM Helper — Mac URL scheme handler
+//
+// Handles popdam://open-folder?path=<encoded-path> by revealing the
+// folder in Finder (NSWorkspace.open). The app is a background-only
+// LSUIElement app: no Dock icon, no window, quits after handling the URL.
+//
+// Build:
+//   swiftc -framework Cocoa main.swift -o "PopDAM Helper"
+//
+// Bundle:
+//   mkdir -p "PopDAM Helper.app/Contents/MacOS"
+//   cp "PopDAM Helper" "PopDAM Helper.app/Contents/MacOS/"
+//   cp Info.plist "PopDAM Helper.app/Contents/"
+//
+// Install:
+//   Move "PopDAM Helper.app" to /Applications (or anywhere), then open it
+//   once. macOS registers the popdam:// scheme automatically on first launch.
+
+import Cocoa
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleGetURL(event:replyEvent:)),
+            forEventClass: AEEventClass(kInternetEventClass),
+            andEventID: AEEventID(kAEGetURL)
+        )
+        // If no URL arrives within 2 s (e.g. user double-clicked the app to
+        // register it), just quit quietly.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            NSApp.terminate(nil)
+        }
+    }
+
+    @objc func handleGetURL(event: NSAppleEventDescriptor, replyEvent: NSAppleEventDescriptor) {
+        defer {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApp.terminate(nil)
+            }
+        }
+
+        guard
+            let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue,
+            let components = URLComponents(string: urlString),
+            let pathItem = components.queryItems?.first(where: { $0.name == "path" }),
+            let rawPath = pathItem.value,
+            !rawPath.isEmpty
+        else { return }
+
+        // Normalize backslashes → forward slashes.
+        // The web app may encode Windows-style UNC paths (\\host\share\folder)
+        // or Synology Drive paths that use backslashes — both work as POSIX
+        // paths once converted (Synology Drive syncs to a local Mac path).
+        let normalizedPath = rawPath.replacingOccurrences(of: "\\", with: "/")
+
+        let url = URL(fileURLWithPath: normalizedPath)
+        NSWorkspace.shared.open(url)
+    }
+}
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/apps/popdam-helper/src/index.ts
+++ b/apps/popdam-helper/src/index.ts
@@ -1,0 +1,94 @@
+/**
+ * PopDAM Helper — Windows protocol handler
+ *
+ * Handles popdam:// URLs from the web app by opening the target folder in Explorer.
+ *
+ * Usage:
+ *   popdam-helper.exe "popdam://open-folder?path=%5C%5Cnas%5Cshare%5Cfolder"
+ *   popdam-helper.exe --register      write HKCU registry keys
+ *   popdam-helper.exe --unregister    remove registry keys
+ */
+
+import { execFileSync, execSync } from "node:child_process";
+import * as path from "node:path";
+
+// When packaged by pkg, process.execPath is the .exe itself.
+const EXE_PATH = process.execPath;
+
+function parsePopDamUrl(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "popdam:") return null;
+    return url.searchParams.get("path");
+  } catch {
+    return null;
+  }
+}
+
+function openFolder(folderPath: string): void {
+  // Normalize forward slashes to backslashes for Windows Explorer
+  const winPath = folderPath.replace(/\//g, "\\");
+  try {
+    execFileSync("explorer.exe", [winPath], { windowsHide: false });
+  } catch {
+    // Explorer returns exit code 1 even on success — ignore
+  }
+}
+
+function regAdd(keyPath: string, valueName: string | null, data: string, type = "REG_SZ"): void {
+  const args = ["add", keyPath, "/t", type, "/d", data, "/f"];
+  if (valueName) {
+    args.push("/v", valueName);
+  } else {
+    args.push("/ve");
+  }
+  execSync(`reg ${args.map(a => `"${a}"`).join(" ")}`, { windowsHide: true, stdio: "pipe" });
+}
+
+function register(): void {
+  const exe = EXE_PATH;
+  const root = "HKCU\\Software\\Classes\\popdam";
+
+  regAdd(root, null, "URL:PopDAM Folder Opener");
+  regAdd(root, "URL Protocol", "");
+  regAdd(`${root}\\DefaultIcon`, null, `${exe},0`);
+  regAdd(`${root}\\shell\\open\\command`, null, `"${exe}" "%1"`);
+
+  console.log(`popdam:// protocol handler registered.`);
+  console.log(`Handler: "${exe}" "%1"`);
+}
+
+function unregister(): void {
+  execSync(`reg delete "HKCU\\Software\\Classes\\popdam" /f`, {
+    windowsHide: true,
+    stdio: "pipe",
+  });
+  console.log("popdam:// protocol handler unregistered.");
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+const arg = process.argv[2];
+
+if (!arg) {
+  console.error("PopDAM Helper");
+  console.error("");
+  console.error("Usage:");
+  console.error("  popdam-helper.exe --register      Register popdam:// protocol handler");
+  console.error("  popdam-helper.exe --unregister    Remove protocol handler");
+  console.error("  popdam-helper.exe <popdam://...>  Open folder (called by browser)");
+  process.exit(1);
+}
+
+if (arg === "--register") {
+  register();
+} else if (arg === "--unregister") {
+  unregister();
+} else {
+  const folderPath = parsePopDamUrl(arg);
+  if (!folderPath) {
+    console.error(`Invalid or unsupported popdam:// URL: ${arg}`);
+    process.exit(1);
+  }
+  openFolder(folderPath);
+}

--- a/apps/popdam-helper/tsconfig.json
+++ b/apps/popdam-helper/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/components/library/AssetDetailPanel.tsx
+++ b/src/components/library/AssetDetailPanel.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { Asset } from "@/types/assets";
-import { getPathDisplayModes, getUserSyncRoot, type NasConfig } from "@/lib/path-utils";
-import { getOpenFolderUri } from "@/lib/open-folder";
+import { getPathDisplayModes, getUserSyncRoot, setUserSyncRoot, type NasConfig } from "@/lib/path-utils";
+import { getOpenFolderUri, getPreferredPathMode, setPreferredPathMode, type PathMode } from "@/lib/open-folder";
 import { formatFilename } from "@/lib/format-filename";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -21,6 +21,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
   X,
   Copy,
   Check,
@@ -33,6 +38,7 @@ import {
   History,
   Loader2,
   FolderOpen,
+  Settings2,
 } from "lucide-react";
 import { Constants } from "@/integrations/supabase/types";
 import { cn } from "@/lib/utils";
@@ -90,6 +96,8 @@ export default function AssetDetailPanel({ asset, onClose }: AssetDetailPanelPro
   const [editingTags, setEditingTags] = useState(false);
   const [tagInput, setTagInput] = useState("");
   const [aiTagging, setAiTagging] = useState(false);
+  const [pathMode, setPathModeState] = useState<PathMode>(getPreferredPathMode);
+  const [syncRoot, setSyncRootState] = useState<string>(getUserSyncRoot() ?? "");
 
   // Fetch NAS config for path display
   const { data: nasConfig } = useQuery({
@@ -307,25 +315,83 @@ export default function AssetDetailPanel({ asset, onClose }: AssetDetailPanelPro
               <HardDrive className="h-3.5 w-3.5" /> Paths
             </h4>
             {nasConfig && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5 text-xs h-7 w-full"
-                asChild
-              >
-                <a
-                  href={getOpenFolderUri(asset.relative_path, nasConfig) ?? "#"}
-                  onClick={(e) => {
-                    if (!getOpenFolderUri(asset.relative_path, nasConfig)) {
-                      e.preventDefault();
-                      toast.error("Cannot open folder", { description: "Set your Synology Drive root in Settings → Path Tester if using remote mode." });
-                    }
-                  }}
+              <div className="flex gap-1.5">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 text-xs h-7 flex-1"
+                  asChild
                 >
-                  <FolderOpen className="h-3 w-3" />
-                  Open Containing Folder
-                </a>
-              </Button>
+                  <a
+                    href={getOpenFolderUri(asset.relative_path, nasConfig, pathMode) ?? "#"}
+                    onClick={(e) => {
+                      if (!getOpenFolderUri(asset.relative_path, nasConfig, pathMode)) {
+                        e.preventDefault();
+                        toast.error("Cannot open folder", {
+                          description: pathMode === "synology_drive"
+                            ? "Set your Synology Drive sync root below (the gear icon)."
+                            : "NAS config missing.",
+                        });
+                      }
+                    }}
+                  >
+                    <FolderOpen className="h-3 w-3" />
+                    Open Containing Folder
+                  </a>
+                </Button>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" size="icon" className="h-7 w-7 shrink-0">
+                      <Settings2 className="h-3 w-3" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-72 p-3 space-y-3" align="end">
+                    <p className="text-xs font-medium">Open Folder Settings</p>
+                    <div className="space-y-1">
+                      <Label className="text-[10px] uppercase text-muted-foreground tracking-wider">Path mode</Label>
+                      <Select
+                        value={pathMode}
+                        onValueChange={(v) => {
+                          setPathModeState(v as PathMode);
+                          setPreferredPathMode(v as PathMode);
+                        }}
+                      >
+                        <SelectTrigger className="h-7 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="unc_host" className="text-xs">Office — UNC hostname</SelectItem>
+                          <SelectItem value="unc_ip" className="text-xs">Office — UNC IP address</SelectItem>
+                          <SelectItem value="synology_drive" className="text-xs">Remote — Synology Drive (Mac/PC)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <p className="text-[10px] text-muted-foreground">
+                        {pathMode === "synology_drive"
+                          ? "For designers working remotely via Synology Drive."
+                          : "For designers on the office network."}
+                      </p>
+                    </div>
+                    {pathMode === "synology_drive" && (
+                      <div className="space-y-1">
+                        <Label className="text-[10px] uppercase text-muted-foreground tracking-wider">Your Synology Drive sync root</Label>
+                        <Input
+                          className="h-7 text-xs font-mono"
+                          value={syncRoot}
+                          onChange={(e) => setSyncRootState(e.target.value)}
+                          onBlur={() => setUserSyncRoot(syncRoot)}
+                          placeholder="/Users/you/Synology Drive"
+                        />
+                        <p className="text-[10px] text-muted-foreground">
+                          The local folder where Synology Drive syncs files. Mac example: <span className="font-mono">/Users/you/Synology Drive</span>
+                        </p>
+                      </div>
+                    )}
+                    <p className="text-[10px] text-muted-foreground border-t pt-2">
+                      Requires the <strong>PopDAM Helper</strong> app installed on this computer. Download it from Settings → Install Bundles.
+                    </p>
+                  </PopoverContent>
+                </Popover>
+              </div>
             )}
             <CopyButton label="Relative" value={asset.relative_path} />
             {paths && (

--- a/src/components/settings/InstallBundleTab.tsx
+++ b/src/components/settings/InstallBundleTab.tsx
@@ -12,7 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "sonner";
 import {
   Download, Server, Plus, Trash2, Package,
-  Loader2, AlertTriangle, FolderPlus,
+  Loader2, AlertTriangle, FolderPlus, FolderOpen, Monitor, Apple,
 } from "lucide-react";
 
 // ── Shared download helper ──────────────────────────────────────────
@@ -245,6 +245,81 @@ function BridgeAgentBundle() {
   );
 }
 
+// ── PopDAM Helper ───────────────────────────────────────────────────
+
+function PopDamHelperCard() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <FolderOpen className="h-4 w-4" />
+          PopDAM Helper
+          <Badge variant="secondary" className="text-[10px]">Windows &amp; Mac</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          A tiny background app that handles the <span className="font-mono text-xs">popdam://</span> protocol.
+          Install it once and the <strong>Open Containing Folder</strong> button in the asset panel will open
+          Explorer or Finder directly to the file — no full render agent required.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Windows */}
+          <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
+            <div className="flex items-center gap-2 text-xs font-medium">
+              <Monitor className="h-3.5 w-3.5" /> Windows
+            </div>
+            <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+              <li>Download and unzip</li>
+              <li>Run <span className="font-mono">Install.bat</span> once (registers protocol)</li>
+              <li>Done — button works in any browser</li>
+            </ol>
+            <Button variant="outline" size="sm" className="gap-1.5 text-xs h-7 w-full" asChild>
+              <a
+                href="https://github.com/u2giants/popdam3/releases/tag/popdam-helper-latest"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Download className="h-3 w-3" />
+                Download for Windows
+              </a>
+            </Button>
+          </div>
+
+          {/* Mac */}
+          <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
+            <div className="flex items-center gap-2 text-xs font-medium">
+              <Apple className="h-3.5 w-3.5" /> Mac
+            </div>
+            <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+              <li>Download and unzip</li>
+              <li>Move <span className="font-mono">PopDAM Helper.app</span> to Applications</li>
+              <li>Open it once to register</li>
+              <li>Set path mode to <em>Synology Drive</em> in asset panel</li>
+            </ol>
+            <Button variant="outline" size="sm" className="gap-1.5 text-xs h-7 w-full" asChild>
+              <a
+                href="https://github.com/u2giants/popdam3/releases/tag/popdam-helper-latest"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Download className="h-3 w-3" />
+                Download for Mac
+              </a>
+            </Button>
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          After installing, click the gear icon next to <strong>Open Containing Folder</strong> in any asset
+          panel to choose your path mode (office UNC, or Synology Drive for remote work).
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 // ── Main Tab ────────────────────────────────────────────────────────
 
 export default function InstallBundleTab() {
@@ -259,6 +334,7 @@ export default function InstallBundleTab() {
           Generate ready-to-run install packages for new agents. Each bundle contains a one-time pairing code — no manual .env editing required.
         </p>
       </div>
+      <PopDamHelperCard />
       <BridgeAgentBundle />
       <Card className="border-dashed">
         <CardContent className="py-4">

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -42,11 +42,20 @@ export function getPathDisplayModes(
   const backslashed = toBackslash(relativePath);
   const share = config.NAS_SHARE;
 
+  // Detect whether the sync root is a Windows path (e.g. "C:\...") or a
+  // Mac/Linux POSIX path (e.g. "/Users/..."). Use the appropriate separator
+  // so the generated path is valid on the user's OS.
+  const isWindowsSyncRoot = userSyncRoot
+    ? /^[A-Za-z]:[/\\]/.test(userSyncRoot)
+    : false;
+  const remoteRelative = isWindowsSyncRoot ? `${share}\\${backslashed}` : `${share}/${relativePath}`;
+  const remoteSep = isWindowsSyncRoot ? "\\" : "/";
+
   return {
     uncHost: `\\\\${config.NAS_HOST}\\${share}\\${backslashed}`,
     uncIp: `\\\\${config.NAS_IP}\\${share}\\${backslashed}`,
     remote: userSyncRoot
-      ? `${userSyncRoot.replace(/[/\\]$/, "")}\\${share}\\${backslashed}`
+      ? `${userSyncRoot.replace(/[/\\]$/, "")}${remoteSep}${remoteRelative}`
       : null,
     container: config.NAS_CONTAINER_MOUNT_ROOT
       ? `${config.NAS_CONTAINER_MOUNT_ROOT.replace(/\/$/, "")}/${relativePath}`


### PR DESCRIPTION
## Summary

Adds `apps/popdam-helper`: a tiny install-once app that registers `popdam://` on the designer's computer so **Open Containing Folder** in the asset panel actually works — without installing the full Windows Render Agent. Works on both Windows and Mac.

### How it works

```
Web app clicks "Open Containing Folder"
  → browser navigates to popdam://open-folder?path=%5C%5Cnas%5Cshare%5Cfolder
    → OS launches the registered popdam-helper app
      → Windows: explorer.exe "\\nas\share\folder"
      → Mac: NSWorkspace.open("/Users/you/Synology Drive/share/folder")
```

### Windows (Node.js + pkg → .exe, ~40 MB)
- `--register` writes `HKCU\Software\Classes\popdam` registry keys
- `--unregister` removes them
- `Install.bat` ships alongside the exe and runs `--register` automatically

### Mac (Swift → `.app` bundle, ~200 KB)
- `CFBundleURLTypes` in `Info.plist` registers `popdam://` with macOS Launch Services on first open
- `LSUIElement = true` → runs as a background app with no Dock icon
- Normalises Windows-style backslash paths to POSIX before calling `NSWorkspace.shared.open()`

### CI (`publish-popdam-helper.yml`)
Two jobs in parallel:
- `windows-latest`: tsc → pkg → zip with Install.bat
- `macos-latest`: `swiftc -framework Cocoa main.swift` → bundle `.app` → zip
Both publish to a `popdam-helper-latest` GitHub release tag.

### Also fixed
- **`path-utils.ts` Mac path bug**: `remote` (Synology Drive) paths now use forward slashes when the sync root is a Mac POSIX path (`/Users/...`) and backslashes when it's a Windows path (`C:\...`). Previously always used backslashes, generating invalid Mac paths.

### UI changes
- **Asset panel**: gear icon next to "Open Containing Folder" opens a popover to choose path mode (office UNC hostname / office UNC IP / Synology Drive remote) and set the local sync root. Preference saved in localStorage per-browser.
- **Settings → Install Bundles**: new "PopDAM Helper" card at the top with per-platform download links and installation instructions.

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS