### PR TITLE
fix: open Alternative Images to all users; exclude _old/SAMPLE from scan

### DIFF
--- a/packages/path-filters/index.ts
+++ b/packages/path-filters/index.ts
@@ -40,6 +40,8 @@ const BLOCKLIST = new Set([
   ".svn",
   "recovered",
   "adobe premiere pro auto-save",
+  "_old",
+  "sample",
 ]);
 
 // ── Prefix characters that trigger automatic skip (Rule A) ──────────

--- a/src/pages/DownloadsPage.tsx
+++ b/src/pages/DownloadsPage.tsx
@@ -1,4 +1,4 @@
-import { Download, Container, Monitor, Copy, Check, ExternalLink, FolderOpen, Terminal } from "lucide-react";
+import { Download, Container, Monitor, Copy, Check, ExternalLink, FolderOpen, Terminal, Apple } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -173,6 +173,61 @@ export default function DownloadsPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
+          {/* Pre-built Binaries (Recommended) */}
+          <div>
+            <h4 className="text-sm font-semibold text-foreground mb-3">Recommended: Pre-Built Binaries</h4>
+            <div className="grid gap-3 md:grid-cols-2">
+              {/* Windows Pre-Built */}
+              <div className="border border-border rounded-md p-3 space-y-2 bg-muted/20">
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-[10px]">Windows</Badge>
+                </div>
+                <ol className="text-xs text-muted-foreground space-y-0.5 list-decimal list-inside">
+                  <li>Download and unzip</li>
+                  <li>Run <span className="font-mono text-[10px]">Install.bat</span> once</li>
+                  <li>Done — works in any browser</li>
+                </ol>
+                <Button variant="outline" size="sm" className="gap-1.5 text-xs h-7 w-full" asChild>
+                  <a
+                    href="https://github.com/u2giants/popdam3/releases/download/popdam-helper-latest/popdam-helper-windows-x64.zip"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Download className="h-3 w-3" />
+                    Download for Windows
+                  </a>
+                </Button>
+              </div>
+
+              {/* Mac Pre-Built */}
+              <div className="border border-border rounded-md p-3 space-y-2 bg-muted/20">
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-[10px]">Mac</Badge>
+                </div>
+                <ol className="text-xs text-muted-foreground space-y-0.5 list-decimal list-inside">
+                  <li>Download and unzip</li>
+                  <li>Move <span className="font-mono text-[10px]">PopDAM Helper.app</span> to Applications</li>
+                  <li>Open it once to register</li>
+                </ol>
+                <Button variant="outline" size="sm" className="gap-1.5 text-xs h-7 w-full" asChild>
+                  <a
+                    href="https://github.com/u2giants/popdam3/releases/download/popdam-helper-latest/popdam-helper-mac.zip"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Download className="h-3 w-3" />
+                    Download for Mac
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <h4 className="text-sm font-semibold text-foreground mb-3">Alternative: Manual Setup</h4>
+            <p className="text-xs text-muted-foreground mb-3">If you prefer not to install the pre-built app, you can manually register the protocol using PowerShell or shell scripts.</p>
+          </div>
+
           <div className="grid gap-4 md:grid-cols-2">
             {/* Windows */}
             <div className="border border-border rounded-md p-4 space-y-3">

--- a/supabase/functions/_shared/path-filters.ts
+++ b/supabase/functions/_shared/path-filters.ts
@@ -30,6 +30,8 @@ const BLOCKLIST = new Set([
   ".svn",
   "recovered",
   "adobe premiere pro auto-save",
+  "_old",
+  "sample",
 ]);
 
 const SKIP_PREFIXES = [".", "$", "@", "#"];

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -84,9 +84,9 @@ import {
   handleUpdateHygieneFindings,
 } from "../_shared/admin-handlers/hygiene-handlers.ts";
 
-// ── Auth: JWT validation + admin role check ─────────────────────────
+// ── Auth: JWT validation only (any authenticated user) ──────────────
 
-async function authenticateAdmin(
+async function authenticateUser(
   req: Request,
 ): Promise<{ userId: string } | Response> {
   const authHeader = req.headers.get("Authorization");
@@ -101,13 +101,13 @@ async function authenticateAdmin(
   if (serviceRoleKey && token === serviceRoleKey) {
     return { userId: "system" };
   }
+
   const anonClient = createClient(
     Deno.env.get("SUPABASE_URL")!,
     Deno.env.get("SUPABASE_ANON_KEY")!,
     { global: { headers: { Authorization: authHeader } } },
   );
 
-  let userId: string;
   try {
     let sub: string | undefined;
     const { data: { user }, error: userError } = await anonClient.auth.getUser(token);
@@ -125,12 +125,22 @@ async function authenticateAdmin(
     } else {
       sub = user.id;
     }
-    userId = sub;
-    console.log("Authenticated userId:", userId);
+    console.log("Authenticated userId:", sub);
+    return { userId: sub };
   } catch (e) {
     console.error("Token validation error:", e);
     return err("Invalid or expired token", 401);
   }
+}
+
+// ── Auth: JWT validation + admin role check ─────────────────────────
+
+async function authenticateAdmin(
+  req: Request,
+): Promise<{ userId: string } | Response> {
+  const authResult = await authenticateUser(req);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
 
   // Check admin role using service client (bypasses RLS)
   const db = serviceClient();
@@ -161,6 +171,15 @@ async function authenticateAdmin(
 
   return { userId };
 }
+
+// ── Actions accessible to any authenticated user (not admin-only) ────
+
+const USER_ACCESSIBLE_ACTIONS = new Set([
+  "list-sibling-images",
+  "get-sibling-scan-result",
+  "get-sibling-scan-by-folder",
+  "ingest-sibling-images",
+]);
 
 // ── Retry helper for transient connection / body-read errors ────────
 
@@ -661,10 +680,7 @@ serve(async (req: Request) => {
   }
 
   try {
-    const authResult = await authenticateAdmin(req);
-    if (authResult instanceof Response) return authResult;
-    const { userId } = authResult;
-
+    // Parse body first so we can determine the action before selecting auth level
     let body: Record<string, unknown>;
     try {
       body = await req.json();
@@ -677,6 +693,13 @@ serve(async (req: Request) => {
     const route = pathSegments[pathSegments.length - 1] || "";
     const action = (body.action as string) || route;
     console.log(`admin-api action: ${action}`);
+
+    // Choose auth level: some actions are open to all authenticated users
+    const authResult = USER_ACCESSIBLE_ACTIONS.has(action)
+      ? await authenticateUser(req)
+      : await authenticateAdmin(req);
+    if (authResult instanceof Response) return authResult;
+    const { userId } = authResult;
 
     switch (action) {
       // ── Config ──

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -695,9 +695,7 @@ serve(async (req: Request) => {
     console.log(`admin-api action: ${action}`);
 
     // Choose auth level: some actions are open to all authenticated users
-    const authResult = USER_ACCESSIBLE_ACTIONS.has(action)
-      ? await authenticateUser(req)
-      : await authenticateAdmin(req);
+    const authResult = USER_ACCESSIBLE_ACTIONS.has(action) ? await authenticateUser(req) : await authenticateAdmin(req);
     if (authResult instanceof Response) return authResult;
     const { userId } = authResult;
 


### PR DESCRIPTION
## Summary

- **Alternative Images panel**: Refactored `admin-api` auth so sibling-scan actions (`list-sibling-images`, `get-sibling-scan-result`, `get-sibling-scan-by-folder`, `ingest-sibling-images`) require only a valid JWT — not admin role. All authenticated users can now use the Alternative Images / sibling finder in the Style Group detail panel.
- **`_old` / `SAMPLE` folder exclusion**: Added `"_old"` and `"sample"` to the case-insensitive blocklist in `packages/path-filters/index.ts` and its Deno copy. The bridge-agent scanner will now skip any subfolder named `_old` or `SAMPLE` (any case) during NAS ingestion.
- Also includes the Downloads page change (pre-built PopDAM Helper binaries).

## Test plan

- [ ] Non-admin user: open Style Group detail panel → Alternative Images should work (no 403)
- [ ] Admin user: Alternative Images should still work
- [ ] Bridge-agent scan with `_old` or `SAMPLE` subfolders → files inside should not be ingested

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS