### PR TITLE
feat: purge assets from _old / SAMPLE subfolders

### DIFF
--- a/src/components/settings/diagnostics/ActionsSection.tsx
+++ b/src/components/settings/diagnostics/ActionsSection.tsx
@@ -77,6 +77,7 @@ export function ActionsSection({ onRefresh, requestOp }: { onRefresh: () => void
   });
 
   const [manifestDownloading, setManifestDownloading] = useState(false);
+  const [isPurgingExcluded, setIsPurgingExcluded] = useState(false);
 
   async function downloadManifest() {
     setManifestDownloading(true);
@@ -117,6 +118,35 @@ export function ActionsSection({ onRefresh, requestOp }: { onRefresh: () => void
       toast.error(e.message || "Manifest download failed");
     } finally {
       setManifestDownloading(false);
+    }
+  }
+
+  async function handlePurgeExcludedSubfolders() {
+    if (!confirm(
+      "This will remove all assets ingested from '_old' or 'SAMPLE' subfolders. " +
+      "Empty style groups will be deleted. This cannot be undone. Continue?"
+    )) return;
+    setIsPurgingExcluded(true);
+    let totalPurged = 0;
+    let totalGroupsRemoved = 0;
+    let totalGroupsUpdated = 0;
+    try {
+      while (true) {
+        const result = await call("purge-excluded-subfolder-assets");
+        totalPurged += result.assets_purged ?? 0;
+        totalGroupsRemoved += result.groups_removed ?? 0;
+        totalGroupsUpdated += result.groups_updated ?? 0;
+        if (result.done) break;
+      }
+      toast.success(
+        `Removed ${totalPurged.toLocaleString()} assets from _old/_SAMPLE folders. ` +
+        `Deleted ${totalGroupsRemoved} empty groups, updated ${totalGroupsUpdated} groups.`
+      );
+      queryClient.invalidateQueries({ queryKey: ["style-groups"] });
+    } catch (e: any) {
+      toast.error(e.message || "Purge failed");
+    } finally {
+      setIsPurgingExcluded(false);
     }
   }
 
@@ -276,6 +306,21 @@ export function ActionsSection({ onRefresh, requestOp }: { onRefresh: () => void
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-[280px] text-center">Nulls out invalid property_name values (like CREATURE) for assets and style groups. Safe to re-run.</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline" size="sm" className="gap-1.5 text-destructive"
+                  onClick={handlePurgeExcludedSubfolders}
+                  disabled={isPurgingExcluded}
+                >
+                  {isPurgingExcluded ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                  {isPurgingExcluded ? "Purging…" : "Purge _old / SAMPLE Assets"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-[280px] text-center">Removes all ingested assets whose path contains a subfolder named _old or SAMPLE (any case). Empty style groups are deleted.</TooltipContent>
             </Tooltip>
           </TooltipProvider>
           <TooltipProvider>

--- a/supabase/functions/_shared/admin-handlers/purge-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/purge-handlers.ts
@@ -100,3 +100,102 @@ export async function handlePurgeOldAssets(body: Record<string, unknown>) {
     remaining: remaining ?? 0,
   });
 }
+
+// ── handlePurgeExcludedSubfolderAssets ──────────────────────────────
+// Soft-deletes assets whose relative_path contains an excluded subfolder
+// segment (_old or SAMPLE, case-insensitive exact segment match).
+// Follows the same batch + group-cleanup pattern as handlePurgeOldAssets.
+
+export async function handlePurgeExcludedSubfolderAssets() {
+  const BATCH_SIZE = 500;
+  const db = serviceClient();
+
+  // Two queries (one per pattern) to avoid PostgREST OR regex parsing issues.
+  // Both use case-insensitive regex (~*) to match the segment exactly.
+  const [q1, q2] = await Promise.all([
+    db.from("assets")
+      .select("id, style_group_id")
+      .eq("is_deleted", false)
+      .filter("relative_path", "~*", "(^|/)_old(/|$)")
+      .order("id")
+      .range(0, BATCH_SIZE - 1),
+    db.from("assets")
+      .select("id, style_group_id")
+      .eq("is_deleted", false)
+      .filter("relative_path", "~*", "(^|/)sample(/|$)")
+      .order("id")
+      .range(0, BATCH_SIZE - 1),
+  ]);
+
+  if (q1.error) return err(q1.error.message, 500);
+  if (q2.error) return err(q2.error.message, 500);
+
+  // Deduplicate (an asset could match both patterns if path has both)
+  const seen = new Set<string>();
+  const assets = [...(q1.data ?? []), ...(q2.data ?? [])].filter((a) => {
+    if (seen.has(a.id)) return false;
+    seen.add(a.id);
+    return true;
+  });
+
+  if (assets.length === 0) {
+    return json({ ok: true, assets_purged: 0, groups_removed: 0, groups_updated: 0, done: true });
+  }
+
+  const assetIds = assets.map((a: any) => a.id);
+  const affectedGroupIds = [
+    ...new Set(assets.map((a: any) => a.style_group_id).filter(Boolean)),
+  ] as string[];
+
+  const { error: deleteErr } = await db
+    .from("assets")
+    .update({ is_deleted: true })
+    .in("id", assetIds);
+  if (deleteErr) return err(deleteErr.message, 500);
+
+  let groupsRemoved = 0;
+  let groupsUpdated = 0;
+
+  if (affectedGroupIds.length > 0) {
+    const { data: groupCounts } = await db
+      .from("assets")
+      .select("style_group_id")
+      .eq("is_deleted", false)
+      .in("style_group_id", affectedGroupIds);
+
+    const groupsWithAssets = new Set((groupCounts ?? []).map((r: any) => r.style_group_id));
+    const emptyGroups = affectedGroupIds.filter((id) => !groupsWithAssets.has(id));
+    const nonEmptyGroups = affectedGroupIds.filter((id) => groupsWithAssets.has(id));
+
+    if (emptyGroups.length > 0) {
+      const { error: delGroupErr } = await db.from("style_groups").delete().in("id", emptyGroups);
+      if (!delGroupErr) groupsRemoved = emptyGroups.length;
+    }
+
+    if (nonEmptyGroups.length > 0) {
+      try {
+        await db.rpc("refresh_style_group_counts_batch", { p_group_ids: nonEmptyGroups });
+        await db.rpc("refresh_style_group_primaries", { p_group_ids: nonEmptyGroups });
+        groupsUpdated = nonEmptyGroups.length;
+      } catch (e) {
+        console.warn("Failed to refresh style group stats after excluded-subfolder purge:", e);
+      }
+    }
+  }
+
+  // Check if more remain (batch may not have covered everything)
+  const [c1, c2] = await Promise.all([
+    db.from("assets").select("id", { count: "exact", head: true }).eq("is_deleted", false).filter("relative_path", "~*", "(^|/)_old(/|$)"),
+    db.from("assets").select("id", { count: "exact", head: true }).eq("is_deleted", false).filter("relative_path", "~*", "(^|/)sample(/|$)"),
+  ]);
+  const remaining = (c1.count ?? 0) + (c2.count ?? 0);
+
+  return json({
+    ok: true,
+    assets_purged: assetIds.length,
+    groups_removed: groupsRemoved,
+    groups_updated: groupsUpdated,
+    done: remaining === 0,
+    remaining,
+  });
+}

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -45,7 +45,7 @@ import { handleApplyErpEnrichment, handleClassifyErpCategories } from "../_share
 
 import { handleBackfillSkuNames, handleReprocessAssetMetadata } from "../_shared/admin-handlers/metadata-handlers.ts";
 
-import { handlePurgeOldAssets } from "../_shared/admin-handlers/purge-handlers.ts";
+import { handlePurgeOldAssets, handlePurgeExcludedSubfolderAssets } from "../_shared/admin-handlers/purge-handlers.ts";
 
 import {
   handleErpEnrichmentStats,
@@ -818,6 +818,8 @@ serve(async (req: Request) => {
       // ── Purge (from purge-handlers.ts) ──
       case "purge-old-assets":
         return await handlePurgeOldAssets(body);
+      case "purge-excluded-subfolder-assets":
+        return await handlePurgeExcludedSubfolderAssets();
 
       // ── ERP (from erp-handlers.ts + erp-browse-handlers.ts) ──
       case "trigger-erp-sync":


### PR DESCRIPTION
## Summary

- New `purge-excluded-subfolder-assets` admin-api action: soft-deletes ingested assets whose `relative_path` contains an `_old` or `SAMPLE` subfolder segment (case-insensitive exact match). Empty style groups are deleted; non-empty ones get their counts refreshed.
- New **"Purge _old / SAMPLE Assets"** button in Settings → Diagnostics → Actions section, with confirm dialog and progress toast.
- Safe to re-run (idempotent — once assets are marked deleted, they no longer appear in the query).

## Test plan

- [ ] Click "Purge _old / SAMPLE Assets" button in Settings → Diagnostics → Actions
- [ ] Confirm dialog appears; on confirm, toast shows count of assets removed and groups affected
- [ ] Assets from `_old`/`SAMPLE` folders no longer appear in library
- [ ] Re-running shows "0 assets" (idempotent)

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS