### PR TITLE
fix: allow non-admin users to sync group tags

### DIFF
--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -179,6 +179,7 @@ const USER_ACCESSIBLE_ACTIONS = new Set([
   "get-sibling-scan-result",
   "get-sibling-scan-by-folder",
   "ingest-sibling-images",
+  "sync-group-tags",
 ]);
 
 // ── Retry helper for transient connection / body-read errors ────────


### PR DESCRIPTION
## Summary
- Adds `sync-group-tags` to `USER_ACCESSIBLE_ACTIONS` in `admin-api` so any authenticated user can call it
- Non-admin users were getting 403 → "Edge Function returned a non-2xx status code" when clicking "Sync Tags to All Group Members" in the style group detail panel

## Root cause
`sync-group-tags` required admin auth. Regular users (9/10 users) couldn't call it, and the 403 response surfaced as the generic "Edge Function returned a non-2xx status code" toast error.

## Test plan
- [ ] Log in as a non-admin user
- [ ] Open a style group detail panel
- [ ] Click "Sync Tags to All Group Members"
- [ ] Verify tags sync successfully with no error toast

https://claude.ai/code/session_01PaoNDD44GxFvWYJMMi3ZsS