### PR TITLE
fix: include eligible PDFs in Alternative Images sibling scan

### DIFF
--- a/apps/bridge-agent/package.json
+++ b/apps/bridge-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popdam-bridge-agent",
 
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "PopDAM Bridge Agent — NAS filesystem scanner, thumbnail generator, and cloud sync worker",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge-agent/src/index.ts
+++ b/apps/bridge-agent/src/index.ts
@@ -17,7 +17,7 @@ import { logger } from "./logger.js";
 import * as api from "./api-client.js";
 import { readFileSync } from "node:fs";
 import { stat, readdir, writeFile, mkdir } from "node:fs/promises";
-import { validateScanRoots, scanFiles, type FileCandidate, type ScanCallbacks } from "./scanner.js";
+import { validateScanRoots, scanFiles, isPdfCandidate, type FileCandidate, type ScanCallbacks } from "./scanner.js";
 import { computeQuickHash } from "./hasher.js";
 import { generateThumbnail, type PdfThumbnailResult } from "./thumbnailer.js";
 import { uploadThumbnail, uploadPdfPage, reinitializeS3Client } from "./uploader.js";
@@ -830,6 +830,9 @@ async function processSiblingScanRequests() {
       const ext = "." + entry.name.split(".").pop()?.toLowerCase();
       if (!extensions.has(ext)) continue;
 
+      // Apply the same PDF keyword filter used by the main scanner
+      if (ext === ".pdf" && !isPdfCandidate(entry.name)) continue;
+
       try {
         const filePath = `${resolved}/${entry.name}`;
         const fileStat = await stat(filePath);
@@ -841,12 +844,18 @@ async function processSiblingScanRequests() {
 
         // Generate and upload a small thumbnail for preview
         try {
-          const sharp = (await import("sharp")).default;
-          const buffer = await sharp(filePath)
-            .flatten({ background: "#ffffff" })
-            .resize(400, 400, { fit: "inside", withoutEnlargement: true })
-            .jpeg({ quality: 75 })
-            .toBuffer();
+          let buffer: Buffer;
+          if (ext === ".pdf") {
+            const thumbResult = await generateThumbnail(filePath, "pdf");
+            buffer = thumbResult.buffer;
+          } else {
+            const sharp = (await import("sharp")).default;
+            buffer = await sharp(filePath)
+              .flatten({ background: "#ffffff" })
+              .resize(400, 400, { fit: "inside", withoutEnlargement: true })
+              .jpeg({ quality: 75 })
+              .toBuffer();
+          }
 
           // Upload to DO Spaces under siblings/ prefix using a hash of relative_path
           const { createHash } = await import("node:crypto");

--- a/apps/bridge-agent/src/scanner.ts
+++ b/apps/bridge-agent/src/scanner.ts
@@ -25,7 +25,7 @@ const PDF_KEYWORDS = [
   "_comp view", "_compview",
 ];
 
-function isPdfCandidate(filename: string): boolean {
+export function isPdfCandidate(filename: string): boolean {
   const lower = filename.toLowerCase();
   return PDF_KEYWORDS.some(kw => lower.includes(kw));
 }

--- a/src/components/library/StyleGroupDetailPanel.tsx
+++ b/src/components/library/StyleGroupDetailPanel.tsx
@@ -163,7 +163,7 @@ function FindAlternativeImages({ group, onIngested }: { group: StyleGroup; onIng
           setSiblings(images);
           setSelected(new Set());
           if (images.length === 0) {
-            toast("No alternative images found", { description: "No JPG/PNG files exist in this folder on the NAS." });
+            toast("No alternative images found", { description: "No JPG, PNG, or eligible PDF files exist in this folder on the NAS." });
           } else {
             toast(`Found ${images.length} image${images.length !== 1 ? "s" : ""}`);
           }
@@ -218,7 +218,7 @@ function FindAlternativeImages({ group, onIngested }: { group: StyleGroup; onIng
         const images = (result.images ?? []) as SiblingImage[];
         setSiblings(images);
         if (images.length === 0) {
-          toast("No alternative images found", { description: "No JPG/PNG files exist in this folder on the NAS." });
+          toast("No alternative images found", { description: "No JPG, PNG, or eligible PDF files exist in this folder on the NAS." });
         }
       } else if (result?.status === "failed") {
         setError(result.error_message || "Scan failed");

--- a/supabase/functions/_shared/admin-handlers/sibling-scan-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/sibling-scan-handlers.ts
@@ -76,7 +76,7 @@ export async function handleListSiblingImages(body: Record<string, unknown>) {
       style_group_id: styleGroupId,
       requested_at: new Date().toISOString(),
       status: "pending",
-      extensions: [".jpg", ".jpeg", ".png"],
+      extensions: [".jpg", ".jpeg", ".png", ".pdf"],
     },
     updated_at: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary

- The sibling scan ("Find JPG/PNG in Folder") was hardcoded to only find `.jpg`/`.jpeg`/`.png` files, so PDFs like `HSR68MVSP01_LICENSING SHEET.pdf` were silently ignored
- Added `.pdf` to the extensions list in `sibling-scan-handlers.ts`
- Exported `isPdfCandidate()` from `scanner.ts` and applied it in the Bridge Agent sibling scan loop — only PDFs matching the same keyword rules as the main scanner (tech pack, licensing sheet, comp view) are included
- Used `generateThumbnail(filePath, "pdf")` for PDF preview thumbnails in the scan results
- Updated UI "no results" toast to mention eligible PDFs alongside JPG/PNG
- Bumped bridge-agent to 1.3.2

https://claude.ai/code/session_01NGYJYgzqUHKWiu7RGrqyhx