### PR TITLE
fix: add read RLS policy so all users can see agent status

### DIFF
--- a/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
+++ b/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
@@ -1,0 +1,8 @@
+-- Allow all authenticated users to read agent_registrations so the
+-- library page and AppHeader can show agent status (bridgeStatus) via
+-- the Supabase JS client. Write operations remain admin-only.
+CREATE POLICY "authenticated users can read agent_registrations"
+  ON public.agent_registrations
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Root cause

`agent_registrations` had only an admin-only `ALL` RLS policy. The `useAgentStatus()` hook queries this table directly via the Supabase JS client (subject to RLS), so every non-admin user got an empty result → `bridgeStatus: "none"` → "No agent" in the header and library page, Sync button permanently greyed out.

17 of 18 users are `role: "user"`, so this affected nearly everyone.

**Why Settings → Agents showed it fine:** that page calls the `admin-api` edge function which uses `serviceClient()` (service role, bypasses RLS entirely).

## Fix

Adds a `SELECT`-only policy for all authenticated users on `agent_registrations`. Write operations remain admin-only.

```sql
CREATE POLICY "authenticated users can read agent_registrations"
  ON public.agent_registrations FOR SELECT TO authenticated USING (true);
```

The migration has already been applied to the remote DB (version `20260325231907`).

https://claude.ai/code/session_01S43tunVNBrVbMihnSjpSpp