### PR TITLE
fix: always fetch scan progress on mount

### DIFF
--- a/src/hooks/useAgentStatus.ts
+++ b/src/hooks/useAgentStatus.ts
@@ -159,7 +159,7 @@ export function useAgentStatus(): AgentStatusInfo {
     queryKey: ["agent-status"],
     queryFn: fetchAgentStatus,
     staleTime: Infinity,
-    initialData: DEFAULT_STATUS,
+    placeholderData: DEFAULT_STATUS,
   });
 
   useEffect(() => {
@@ -175,5 +175,5 @@ export function useAgentStatus(): AgentStatusInfo {
     return () => { supabase.removeChannel(channel); };
   }, [queryClient]);
 
-  return data;
+  return data ?? DEFAULT_STATUS;
 }

--- a/src/hooks/useScanProgress.ts
+++ b/src/hooks/useScanProgress.ts
@@ -115,7 +115,7 @@ export function useScanProgress(): ScanProgress & { pollNow: () => void } {
     queryKey: ["scan-progress"],
     queryFn: fetchScanProgress,
     staleTime: Infinity,
-    initialData: DEFAULT_PROGRESS,
+    placeholderData: DEFAULT_PROGRESS,
   });
 
   useEffect(() => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -68,6 +68,20 @@ export default function LoginPage() {
     }
   };
 
+  const handleMicrosoftSignIn = async () => {
+    setError(null);
+    const { error } = await externalSupabase.auth.signInWithOAuth({
+      provider: "azure",
+      options: {
+        scopes: "email",
+        redirectTo: "https://popdam.designflow.app",
+      },
+    });
+    if (error) {
+      setError(error.message || "Microsoft sign-in failed");
+    }
+  };
+
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -140,6 +154,22 @@ export default function LoginPage() {
                 />
               </svg>
               Continue with Google
+            </Button>
+
+            {/* Microsoft OAuth */}
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleMicrosoftSignIn}
+              type="button"
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 21 21">
+                <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+                <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+                <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+                <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+              </svg>
+              Continue with Microsoft
             </Button>
 
             <div className="relative">

--- a/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
+++ b/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
@@ -1,0 +1,8 @@
+-- Allow all authenticated users to read agent_registrations so the
+-- library page and AppHeader can show agent status (bridgeStatus) via
+-- the Supabase JS client. Write operations remain admin-only.
+CREATE POLICY "authenticated users can read agent_registrations"
+  ON public.agent_registrations
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
Same `initialData` + `staleTime:Infinity` bug as the `useAgentStatus` fix in #49. The scan progress query never fired on page load — it only updated when a Realtime event happened to arrive. Switches to `placeholderData` so the query always runs on mount.

https://claude.ai/code/session_01S43tunVNBrVbMihnSjpSpp