### PR TITLE
Add tooltip titles to all disabled/greyed-out buttons app-wide

### DIFF
--- a/src/components/library/AssetDetailPanel.tsx
+++ b/src/components/library/AssetDetailPanel.tsx
@@ -527,6 +527,7 @@ export default function AssetDetailPanel({ asset, onClose }: AssetDetailPanelPro
                   className="h-6 text-[10px] gap-1"
                   onClick={handleAiTag}
                   disabled={aiTagging || !asset.thumbnail_url}
+                  title={aiTagging ? "Re-tagging in progress…" : !asset.thumbnail_url ? "Requires a thumbnail to run AI analysis" : undefined}
                 >
                   {aiTagging ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
                   {aiTagging ? "Re-tagging…" : "Re-tag"}
@@ -541,6 +542,7 @@ export default function AssetDetailPanel({ asset, onClose }: AssetDetailPanelPro
                   className="gap-1.5"
                   onClick={handleAiTag}
                   disabled={aiTagging || !asset.thumbnail_url}
+                  title={aiTagging ? "Generating AI description…" : !asset.thumbnail_url ? "Requires a thumbnail to run AI analysis" : undefined}
                 >
                   {aiTagging ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
                   {aiTagging ? "Generating…" : "Generate AI Description"}

--- a/src/components/library/StyleGroupDetailPanel.tsx
+++ b/src/components/library/StyleGroupDetailPanel.tsx
@@ -297,6 +297,7 @@ function FindAlternativeImages({ group, onIngested }: { group: StyleGroup; onIng
         className="gap-1.5 text-xs h-7"
         onClick={handleFind}
         disabled={loading || polling}
+        title={loading ? "Scanning folder…" : polling ? "Waiting for agent response…" : undefined}
       >
         {loading || polling ? <Loader2 className="h-3 w-3 animate-spin" /> : <FolderSearch className="h-3 w-3" />}
         {loading ? "Scanning…" : polling ? "Waiting for results…" : siblings ? "Re-scan Folder" : "Find JPG/PNG in Folder"}
@@ -372,6 +373,7 @@ function FindAlternativeImages({ group, onIngested }: { group: StyleGroup; onIng
               className="w-full gap-1.5 text-xs h-7"
               onClick={handleIngest}
               disabled={ingesting}
+              title={ingesting ? "Adding images to group, please wait…" : undefined}
             >
               {ingesting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
               Add {selected.size} Image{selected.size !== 1 ? "s" : ""} to Group
@@ -860,6 +862,7 @@ export default function StyleGroupDetailPanel({ group, onClose }: StyleGroupDeta
                       className="h-7 text-xs w-full"
                       onClick={handleSyncGroupTags}
                       disabled={syncingTags}
+                      title={syncingTags ? "Syncing tags to all group members, please wait…" : undefined}
                     >
                       {syncingTags ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <Tag className="h-3 w-3 mr-1" />}
                       Sync Tags to All Group Members
@@ -889,7 +892,7 @@ export default function StyleGroupDetailPanel({ group, onClose }: StyleGroupDeta
                           <p className="text-xs text-foreground/80 leading-relaxed mt-0.5">{detailAsset.scene_description}</p>
                         </div>
                       )}
-                      <Button variant="ghost" size="sm" className="h-6 text-[10px] gap-1" onClick={handleAiTag} disabled={aiTagging || !detailAsset.thumbnail_url}>
+                      <Button variant="ghost" size="sm" className="h-6 text-[10px] gap-1" onClick={handleAiTag} disabled={aiTagging || !detailAsset.thumbnail_url} title={aiTagging ? "AI tagging in progress…" : !detailAsset.thumbnail_url ? "Requires a thumbnail to run AI analysis" : undefined}>
                         {aiTagging ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
                         {aiTagging ? "Re-tagging…" : "Re-tag"}
                       </Button>
@@ -897,7 +900,7 @@ export default function StyleGroupDetailPanel({ group, onClose }: StyleGroupDeta
                   ) : (
                     <div className="rounded-lg border border-dashed border-border p-3 text-center space-y-2">
                       <p className="text-xs text-muted-foreground">No AI analysis yet</p>
-                      <Button variant="outline" size="sm" className="gap-1.5" onClick={handleAiTag} disabled={aiTagging || !detailAsset.thumbnail_url}>
+                      <Button variant="outline" size="sm" className="gap-1.5" onClick={handleAiTag} disabled={aiTagging || !detailAsset.thumbnail_url} title={aiTagging ? "Generating AI description…" : !detailAsset.thumbnail_url ? "Requires a thumbnail to run AI analysis" : undefined}>
                         {aiTagging ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
                         {aiTagging ? "Generating…" : "Generate AI Description"}
                       </Button>

--- a/src/components/settings/ApisTab.tsx
+++ b/src/components/settings/ApisTab.tsx
@@ -164,6 +164,7 @@ function TaxonomySourceEditor() {
             className="text-xs shrink-0"
             onClick={() => syncMutation.mutate(src.code)}
             disabled={syncMutation.isPending || !src.enabled}
+            title={!src.enabled ? "Enable this integration first" : syncMutation.isPending ? "Sync in progress…" : undefined}
           >
             Sync
           </Button>
@@ -214,7 +215,7 @@ function TaxonomySourceEditor() {
             </div>
           </div>
           <div className="flex gap-2">
-            <Button size="sm" onClick={handleAdd} disabled={saving}>
+            <Button size="sm" onClick={handleAdd} disabled={saving} title={saving ? "Saving…" : undefined}>
               {saving ? "Saving…" : "Save Source"}
             </Button>
             <Button size="sm" variant="ghost" onClick={() => setAdding(false)}>Cancel</Button>
@@ -342,7 +343,7 @@ function TaxonomyApiSection() {
           variant="outline"
           size="sm"
           onClick={() => syncAllMutation.mutate()}
-          disabled={syncAllMutation.isPending}
+          disabled={syncAllMutation.isPending} title={syncAllMutation.isPending ? "Sync in progress…" : undefined}
           className="gap-1.5"
         >
           <RefreshCw className={`h-3.5 w-3.5 ${syncAllMutation.isPending ? "animate-spin" : ""}`} />
@@ -495,6 +496,7 @@ export function AiTaggingInstructionsSection() {
             className="gap-1.5"
             onClick={save}
             disabled={saving || !isDirty}
+            title={!isDirty ? "No unsaved changes" : saving ? "Saving…" : undefined}
           >
             <Save className="h-3.5 w-3.5" />
             {saving ? "Saving…" : "Save Instructions"}
@@ -570,7 +572,7 @@ export function CharacterStatsSection() {
           variant="outline"
           className="gap-1.5"
           onClick={() => rebuildMutation.mutate()}
-          disabled={rebuildMutation.isPending}
+          disabled={rebuildMutation.isPending} title={rebuildMutation.isPending ? "Rebuilding…" : undefined}
         >
           <RefreshCw className={`h-3.5 w-3.5 ${rebuildMutation.isPending ? "animate-spin" : ""}`} />
           {rebuildMutation.isPending ? "Rebuilding…" : "Rebuild Stats"}

--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -85,7 +85,7 @@ function ErpSyncSection() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="outline" size="sm" onClick={() => handleSync(true)} disabled={syncing} className="gap-1.5">
+              <Button variant="outline" size="sm" onClick={() => handleSync(true)} disabled={syncing} title={syncing ? "Sync in progress…" : undefined} className="gap-1.5">
                 <Database className="h-3.5 w-3.5" />
                 Full Sync
               </Button>
@@ -94,7 +94,7 @@ function ErpSyncSection() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button size="sm" onClick={() => handleSync(false)} disabled={syncing} className="gap-1.5">
+              <Button size="sm" onClick={() => handleSync(false)} disabled={syncing} title={syncing ? "Sync in progress…" : undefined} className="gap-1.5">
                 {syncing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
                 {syncing ? "Syncing..." : "Incremental Sync"}
               </Button>
@@ -929,7 +929,7 @@ function ReviewQueue() {
                     variant="outline"
                     className="text-xs gap-1"
                     onClick={() => bulkRejectMutation.mutate([...selectedIds])}
-                    disabled={bulkRejectMutation.isPending}
+                    disabled={bulkRejectMutation.isPending} title={bulkRejectMutation.isPending ? "Processing…" : undefined}
                   >
                     Reject {selectedIds.size}
                   </Button>
@@ -943,7 +943,7 @@ function ReviewQueue() {
                     variant="destructive"
                     className="text-xs gap-1"
                     onClick={() => bulkDismissMutation.mutate([...selectedIds])}
-                    disabled={bulkDismissMutation.isPending}
+                    disabled={bulkDismissMutation.isPending} title={bulkDismissMutation.isPending ? "Processing…" : undefined}
                   >
                     Dismiss {selectedIds.size}
                   </Button>
@@ -1075,7 +1075,7 @@ function ReviewQueue() {
                                   variant="ghost"
                                   className="h-6 w-6 p-0 text-[hsl(var(--success))]"
                                   onClick={() => actionMutation.mutate({ id: item.id, action: "approve" })}
-                                  disabled={actionMutation.isPending}
+                                  disabled={actionMutation.isPending} title={actionMutation.isPending ? "Processing…" : undefined}
                                 >
                                   <Check className="h-3.5 w-3.5" />
                                 </Button>
@@ -1113,7 +1113,7 @@ function ReviewQueue() {
                                   variant="ghost"
                                   className="h-6 w-6 p-0 text-destructive"
                                   onClick={() => actionMutation.mutate({ id: item.id, action: "reject" })}
-                                  disabled={actionMutation.isPending}
+                                  disabled={actionMutation.isPending} title={actionMutation.isPending ? "Processing…" : undefined}
                                 >
                                   <X className="h-3.5 w-3.5" />
                                 </Button>
@@ -1129,7 +1129,7 @@ function ReviewQueue() {
                                   variant="ghost"
                                   className="h-6 text-xs text-[hsl(var(--warning))] gap-1"
                                   onClick={() => actionMutation.mutate({ id: item.id, action: "revert" })}
-                                  disabled={actionMutation.isPending}
+                                  disabled={actionMutation.isPending} title={actionMutation.isPending ? "Processing…" : undefined}
                                 >
                                   <Undo2 className="h-3 w-3" /> Undo
                                 </Button>
@@ -1153,10 +1153,10 @@ function ReviewQueue() {
               Page {page} of {totalPages} ({total} items)
             </span>
             <div className="flex items-center gap-1">
-              <Button size="sm" variant="outline" className="h-7" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              <Button size="sm" variant="outline" className="h-7" disabled={page <= 1} title={page <= 1 ? "Already on the first page" : undefined} onClick={() => setPage((p) => p - 1)}>
                 <ChevronLeft className="h-3 w-3" />
               </Button>
-              <Button size="sm" variant="outline" className="h-7" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+              <Button size="sm" variant="outline" className="h-7" disabled={page >= totalPages} title={page >= totalPages ? "Already on the last page" : undefined} onClick={() => setPage((p) => p + 1)}>
                 <ChevronRight className="h-3 w-3" />
               </Button>
             </div>
@@ -1327,7 +1327,7 @@ function ErpItemsBrowser() {
                 variant="destructive"
                 className="text-xs gap-1"
                 onClick={() => dismissMutation.mutate({ ids: [...selectedIds], dismiss: true })}
-                disabled={dismissMutation.isPending}
+                disabled={dismissMutation.isPending} title={dismissMutation.isPending ? "Dismissing…" : undefined}
               >
                 <X className="h-3.5 w-3.5" />
                 Dismiss {selectedIds.size}
@@ -1338,7 +1338,7 @@ function ErpItemsBrowser() {
                   variant="outline"
                   className="text-xs gap-1"
                   onClick={() => dismissMutation.mutate({ ids: [...selectedIds], dismiss: false })}
-                  disabled={dismissMutation.isPending}
+                  disabled={dismissMutation.isPending} title={dismissMutation.isPending ? "Dismissing…" : undefined}
                 >
                   <Undo2 className="h-3.5 w-3.5" />
                   Restore {selectedIds.size}
@@ -1570,11 +1570,11 @@ function ErpItemsBrowser() {
                 Showing {((page - 1) * pageSize) + 1}–{Math.min(page * pageSize, total)} of {total.toLocaleString()}
               </span>
               <div className="flex items-center gap-1">
-                <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page <= 1} title={page <= 1 ? "Already on the first page" : undefined} onClick={() => setPage(page - 1)}>
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
                 <span className="px-2">Page {page} of {totalPages}</span>
-                <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page >= totalPages} title={page >= totalPages ? "Already on the last page" : undefined} onClick={() => setPage(page + 1)}>
                   <ChevronRight className="h-4 w-4" />
                 </Button>
               </div>

--- a/src/components/settings/FileHygieneTab.tsx
+++ b/src/components/settings/FileHygieneTab.tsx
@@ -236,7 +236,7 @@ export default function FileHygieneTab() {
             <ShieldAlert className="h-4 w-4" /> File Hygiene
           </CardTitle>
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isLoading}>
+            <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isLoading} title={isLoading ? "Loading…" : undefined}>
               <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${isLoading ? "animate-spin" : ""}`} />
               Refresh
             </Button>
@@ -244,6 +244,7 @@ export default function FileHygieneTab() {
               variant="default" size="sm"
               onClick={() => scanMutation.mutate()}
               disabled={scanMutation.isPending || isAgentScanning}
+              title={isAgentScanning ? "Agent is already scanning" : scanMutation.isPending ? "Scan requested, please wait…" : undefined}
               className="gap-1.5"
             >
               {(scanMutation.isPending || isAgentScanning)
@@ -309,14 +310,14 @@ export default function FileHygieneTab() {
               <Button
                 variant="outline" size="sm" className="gap-1.5 text-xs h-7"
                 onClick={() => dismissMutation.mutate([...selectedIds])}
-                disabled={dismissMutation.isPending}
+                disabled={dismissMutation.isPending} title={dismissMutation.isPending ? "Dismissing…" : undefined}
               >
                 <EyeOff className="h-3 w-3" /> Dismiss
               </Button>
               <Button
                 variant="default" size="sm" className="gap-1.5 text-xs h-7"
                 onClick={() => resolveMutation.mutate([...selectedIds])}
-                disabled={resolveMutation.isPending}
+                disabled={resolveMutation.isPending} title={resolveMutation.isPending ? "Resolving…" : undefined}
               >
                 <CheckCircle2 className="h-3 w-3" /> Resolve
               </Button>

--- a/src/components/settings/ScanProgressPanel.tsx
+++ b/src/components/settings/ScanProgressPanel.tsx
@@ -156,6 +156,7 @@ export function ScanProgressPanel({
               className="h-6 text-[10px] gap-1 px-2"
               onClick={onStop}
               disabled={stopPending}
+              title={stopPending ? "Stop request sent, waiting for agent…" : undefined}
             >
               <Square className="h-2.5 w-2.5" /> Stop
             </Button>

--- a/src/components/settings/StyleGuideCrawlTab.tsx
+++ b/src/components/settings/StyleGuideCrawlTab.tsx
@@ -82,6 +82,7 @@ export default function StyleGuideCrawlTab() {
             className="gap-1.5"
             onClick={() => triggerMutation.mutate()}
             disabled={isActive || triggerMutation.isPending}
+            title={isActive ? "Crawl is already running" : triggerMutation.isPending ? "Starting crawl…" : undefined}
           >
             {isActive ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -267,10 +268,10 @@ export default function StyleGuideCrawlTab() {
                   {((page - 1) * 50 + 1).toLocaleString()}–{Math.min(page * 50, totalFiles).toLocaleString()} of {totalFiles.toLocaleString()}
                 </span>
                 <div className="flex gap-1">
-                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page <= 1} title={page <= 1 ? "Already on the first page" : undefined} onClick={() => setPage(page - 1)}>
                     <ChevronLeft className="h-3.5 w-3.5" />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={page >= totalPages} title={page >= totalPages ? "Already on the last page" : undefined} onClick={() => setPage(page + 1)}>
                     <ChevronRight className="h-3.5 w-3.5" />
                   </Button>
                 </div>

--- a/src/components/settings/TiffHygieneTab.tsx
+++ b/src/components/settings/TiffHygieneTab.tsx
@@ -288,7 +288,7 @@ export default function TiffHygieneTab() {
             <FileImage className="h-4 w-4" /> TIFF Compression Hygiene
           </CardTitle>
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isLoading}>
+            <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isLoading} title={isLoading ? "Loading…" : undefined}>
               <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${isLoading ? "animate-spin" : ""}`} />
               Refresh
             </Button>
@@ -296,6 +296,7 @@ export default function TiffHygieneTab() {
               variant="default" size="sm"
               onClick={() => scanMutation.mutate()}
               disabled={scanMutation.isPending || isAgentScanning}
+              title={isAgentScanning ? "Agent is already scanning" : scanMutation.isPending ? "Scan requested, please wait…" : undefined}
               className="gap-1.5"
             >
               {(scanMutation.isPending || isAgentScanning) ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
@@ -317,6 +318,7 @@ export default function TiffHygieneTab() {
                 }
               }}
               disabled={refreshDatesMutation.isPending}
+              title={refreshDatesMutation.isPending ? "Refreshing…" : undefined}
               className="gap-1.5"
             >
               {refreshDatesMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
@@ -328,7 +330,7 @@ export default function TiffHygieneTab() {
                   <TooltipTrigger asChild>
                     <Button variant="ghost" size="sm" onClick={() => {
                       if (confirm("Clear all TIFF scan results?")) clearMutation.mutate();
-                    }} disabled={clearMutation.isPending} className="text-destructive">
+                    }} disabled={clearMutation.isPending} title={clearMutation.isPending ? "Clearing…" : undefined} className="text-destructive">
                       <Trash2 className="h-3.5 w-3.5 mr-1" /> Clear
                     </Button>
                   </TooltipTrigger>
@@ -398,7 +400,7 @@ export default function TiffHygieneTab() {
                               .map((f) => f.id);
                             if (ids.length > 0) queueMutation.mutate({ ids, mode: "test" });
                           }}
-                          disabled={queueMutation.isPending}
+                          disabled={queueMutation.isPending} title={queueMutation.isPending ? "Queuing…" : undefined}
                         >
                           <TestTube className="h-3 w-3" /> Test
                         </Button>
@@ -420,7 +422,7 @@ export default function TiffHygieneTab() {
                             if (ids.length > 0 && confirm(`Process ${ids.length} file(s)? Originals will be replaced in-place.`))
                               queueMutation.mutate({ ids, mode: "process" });
                           }}
-                          disabled={queueMutation.isPending}
+                          disabled={queueMutation.isPending} title={queueMutation.isPending ? "Queuing…" : undefined}
                         >
                           <Play className="h-3 w-3" /> Process
                         </Button>
@@ -445,7 +447,7 @@ export default function TiffHygieneTab() {
                           if (ids.length > 0 && confirm(`Delete ${ids.length} original (_big) backup(s)?`))
                             deleteMutation.mutate(ids);
                         }}
-                        disabled={deleteMutation.isPending}
+                        disabled={deleteMutation.isPending} title={deleteMutation.isPending ? "Deleting…" : undefined}
                       >
                         <Trash2 className="h-3 w-3" /> Delete Originals
                       </Button>

--- a/src/components/settings/WindowsAgentTab.tsx
+++ b/src/components/settings/WindowsAgentTab.tsx
@@ -119,7 +119,7 @@ function WindowsAgentStatus({ pollFast }: { pollFast?: boolean }) {
             Live
           </Badge>
         </CardTitle>
-        <Button variant="ghost" size="icon" onClick={() => refetch()} disabled={isRefetching}>
+        <Button variant="ghost" size="icon" onClick={() => refetch()} disabled={isRefetching} title={isRefetching ? "Refreshing…" : "Refresh"}>
           <RefreshCw className={`h-4 w-4 ${isRefetching ? "animate-spin" : ""}`} />
         </Button>
       </CardHeader>
@@ -176,7 +176,7 @@ function WindowsAgentStatus({ pollFast }: { pollFast?: boolean }) {
                           size="sm"
                           className="gap-1 h-7 text-xs"
                           onClick={() => triggerUpdateMutation.mutate(agent.id as string)}
-                          disabled={triggerUpdateMutation.isPending}
+                          disabled={triggerUpdateMutation.isPending} title={triggerUpdateMutation.isPending ? "Requesting update…" : undefined}
                         >
                           <ArrowUpCircle className="h-3 w-3" />
                           Update Now
@@ -192,7 +192,7 @@ function WindowsAgentStatus({ pollFast }: { pollFast?: boolean }) {
                               removeAgentMutation.mutate(agent.id as string);
                             }
                           }}
-                          disabled={removeAgentMutation.isPending}
+                          disabled={removeAgentMutation.isPending} title={removeAgentMutation.isPending ? "Removing agent…" : undefined}
                         >
                           <Trash2 className="h-3 w-3" />
                           Remove
@@ -516,7 +516,7 @@ function WindowsAgentSetup({ onTokenGenerated }: { onTokenGenerated: () => void 
                 size="sm"
                 className="gap-1.5"
                 onClick={() => generateTokenMutation.mutate()}
-                disabled={generateTokenMutation.isPending}
+                disabled={generateTokenMutation.isPending} title={generateTokenMutation.isPending ? "Generating token…" : undefined}
               >
                 <KeyRound className="h-3.5 w-3.5" />
                 Generate New Token
@@ -527,7 +527,7 @@ function WindowsAgentSetup({ onTokenGenerated }: { onTokenGenerated: () => void 
               size="sm"
               className="gap-1.5"
               onClick={() => generateTokenMutation.mutate()}
-              disabled={generateTokenMutation.isPending}
+              disabled={generateTokenMutation.isPending} title={generateTokenMutation.isPending ? "Generating token…" : undefined}
             >
               <KeyRound className="h-3.5 w-3.5" />
               {generateTokenMutation.isPending ? "Generating..." : "Generate Install Token"}
@@ -601,7 +601,7 @@ function WindowsAgentSetup({ onTokenGenerated }: { onTokenGenerated: () => void 
             </div>
             <p className="text-xs text-muted-foreground">Stored in your private database. Delivered to the agent automatically — no file editing required.</p>
           </div>
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             Save NAS Settings
           </Button>
         </div>
@@ -632,6 +632,7 @@ function WindowsAgentSetup({ onTokenGenerated }: { onTokenGenerated: () => void 
             className="gap-1.5"
             onClick={sendTestJob}
             disabled={testStatus === "sending" || testStatus === "polling"}
+            title={testStatus === "sending" ? "Sending test job…" : testStatus === "polling" ? "Waiting for test result…" : undefined}
           >
             <Play className="h-3.5 w-3.5" />
             {testStatus === "sending" ? "Sending..." : testStatus === "polling" ? "Waiting for result..." : "Send Test Job"}
@@ -834,7 +835,7 @@ function RenderJobsTable() {
                 requeueAllMutation.mutate();
               }
             }}
-            disabled={requeueAllMutation.isPending}
+            disabled={requeueAllMutation.isPending} title={requeueAllMutation.isPending ? "Requeueing…" : undefined}
           >
             <RotateCcw className="h-3.5 w-3.5" />
             {requeueAllMutation.isPending ? "Queueing..." : "Requeue All No-Preview"}
@@ -844,7 +845,7 @@ function RenderJobsTable() {
             size="sm"
             className="gap-1.5"
             onClick={() => clearJunkMutation.mutate()}
-            disabled={clearJunkMutation.isPending}
+            disabled={clearJunkMutation.isPending} title={clearJunkMutation.isPending ? "Clearing…" : undefined}
           >
             <Trash2 className="h-3.5 w-3.5" />
             {clearJunkMutation.isPending ? "Clearing..." : "Clear Junk Files"}
@@ -854,7 +855,7 @@ function RenderJobsTable() {
             size="sm"
             className="gap-1.5 text-destructive"
             onClick={() => clearFailedMutation.mutate()}
-            disabled={clearFailedMutation.isPending}
+            disabled={clearFailedMutation.isPending} title={clearFailedMutation.isPending ? "Clearing…" : undefined}
           >
             <Trash2 className="h-3.5 w-3.5" /> Clear Failed
           </Button>
@@ -980,7 +981,7 @@ function RenderJobsTable() {
                                     e.stopPropagation();
                                     requeueMutation.mutate(jobId);
                                   }}
-                                  disabled={requeueMutation.isPending}
+                                  disabled={requeueMutation.isPending} title={requeueMutation.isPending ? "Requeueing…" : undefined}
                                 >
                                   <RotateCcw className="h-3.5 w-3.5" />
                                 </Button>
@@ -1206,7 +1207,7 @@ function RenderPolicyEditor() {
         </div>
 
         {isDirty && (
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             <Save className="h-3.5 w-3.5 mr-1.5" /> Save Policy
           </Button>
         )}

--- a/src/components/settings/WorkerManagementTab.tsx
+++ b/src/components/settings/WorkerManagementTab.tsx
@@ -114,7 +114,7 @@ function SpacesConfigSettings() {
           Stored securely in your private database. Delivered to the agent automatically — no .env editing required.
         </p>
         {isDirty && (
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             <Save className="h-3.5 w-3.5 mr-1.5" /> Save Spaces Config
           </Button>
         )}
@@ -184,6 +184,7 @@ function PathTestButton({ hostPath, mountRoot, scanRoots }: { hostPath: string; 
         size="sm"
         onClick={startTest}
         disabled={status === "waiting" || !mountRoot}
+        title={!mountRoot ? "Enter a container mount path above first" : status === "waiting" ? "Waiting for agent response…" : undefined}
         className="gap-1.5"
       >
         {status === "waiting" ? (
@@ -457,7 +458,7 @@ function FolderManager() {
           )}
           <PathTestButton hostPath={hostPathValue} mountRoot={mountRootValue} scanRoots={roots} />
           {pathsDirty && (
-            <Button size="sm" onClick={() => savePathsMutation.mutate()} disabled={savePathsMutation.isPending}>
+            <Button size="sm" onClick={() => savePathsMutation.mutate()} disabled={savePathsMutation.isPending} title={savePathsMutation.isPending ? "Saving…" : undefined}>
               <Save className="h-3.5 w-3.5 mr-1.5" /> Save Mapping
             </Button>
           )}
@@ -481,7 +482,7 @@ function FolderManager() {
             placeholder="Decor/Projects"
             onKeyDown={(e) => e.key === "Enter" && addFolder()}
           />
-          <Button size="sm" onClick={addFolder} disabled={!newFolder.trim()}>
+          <Button size="sm" onClick={addFolder} disabled={!newFolder.trim()} title={!newFolder.trim() ? "Enter a folder path first" : undefined}>
             <FolderPlus className="h-3.5 w-3.5 mr-1.5" /> Add Folder
           </Button>
         </div>
@@ -525,7 +526,7 @@ function FolderManager() {
             placeholder="Character Licensed"
             onKeyDown={(e) => e.key === "Enter" && addSubfilter()}
           />
-          <Button size="sm" onClick={addSubfilter} disabled={!newSubfilter.trim()}>
+          <Button size="sm" onClick={addSubfilter} disabled={!newSubfilter.trim()} title={!newSubfilter.trim() ? "Enter a value first" : undefined}>
             Add
           </Button>
         </div>
@@ -759,7 +760,7 @@ function ResourceGuardSettings() {
         </div>
 
         {dirty && (
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             <Save className="h-3.5 w-3.5 mr-1.5" /> Save Resource Guard
           </Button>
         )}
@@ -826,7 +827,7 @@ function PollingConfig() {
           </div>
         </div>
         {form && (
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             <Save className="h-3.5 w-3.5 mr-1.5" /> Save Polling Config
           </Button>
         )}
@@ -970,7 +971,7 @@ function DateCutoffSettings() {
         </div>
         <div className="flex flex-wrap gap-2">
           {dirty && (
-            <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+            <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
               <Save className="h-3.5 w-3.5 mr-1.5" /> Save Date Cutoffs
             </Button>
           )}
@@ -979,6 +980,7 @@ function DateCutoffSettings() {
             size="sm"
             onClick={handlePurge}
             disabled={isPurging || !thumbVal || !purgePreview}
+            title={isPurging ? "Purge in progress…" : !thumbVal ? "Configure a thumbnail storage setting first" : !purgePreview ? "Preview the purge results first" : undefined}
           >
             {isPurging ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : <Trash2 className="h-3.5 w-3.5 mr-1.5" />}
             Purge {purgePreview?.toLocaleString() ?? "…"} assets older than {thumbVal}
@@ -1089,7 +1091,7 @@ function ImageOutputSettings() {
         </div>
 
         {dirty && (
-          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
             <Save className="h-3.5 w-3.5 mr-1.5" /> Save Image Settings
           </Button>
         )}
@@ -1220,7 +1222,7 @@ function AutoScanSettings() {
               How often the agent re-scans all configured folders. Default: 6 hours.
             </p>
             {intervalHours !== null && (
-              <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+              <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending} title={saveMutation.isPending ? "Saving…" : undefined}>
                 <Save className="h-3.5 w-3.5 mr-1.5" /> Save Interval
               </Button>
             )}
@@ -1321,6 +1323,7 @@ export function UpdateAgentButton() {
           size="sm"
           onClick={handleUpdate}
           disabled={isPending}
+          title={isPending ? "Update request in progress…" : undefined}
           className="gap-1.5"
         >
           {isPending ? (

--- a/src/components/settings/diagnostics/DatabaseInspector.tsx
+++ b/src/components/settings/diagnostics/DatabaseInspector.tsx
@@ -103,7 +103,7 @@ export function DatabaseInspector() {
           <Button
             variant="outline" size="sm" className="gap-1.5"
             onClick={() => runQuery()}
-            disabled={isRunning || !sql.trim()}
+            disabled={isRunning || !sql.trim()} title={isRunning ? "Query running…" : !sql.trim() ? "Enter a SQL query first" : undefined}
           >
             {isRunning ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
             Run Query

--- a/src/components/settings/diagnostics/QueueManagerDialog.tsx
+++ b/src/components/settings/diagnostics/QueueManagerDialog.tsx
@@ -66,10 +66,10 @@ export function QueueManagerDialog({ open, onOpenChange, queuedItems, onQueueCha
                   <span className="text-xs text-muted-foreground ml-2">#{index + 1}</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === 0} onClick={() => handleReorderQueue(index, -1)}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === 0} title={index === 0 ? "Already at the top of the queue" : undefined} onClick={() => handleReorderQueue(index, -1)}>
                     <ArrowUp className="h-3.5 w-3.5" />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === queuedItems.length - 1} onClick={() => handleReorderQueue(index, 1)}>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === queuedItems.length - 1} title={index === queuedItems.length - 1 ? "Already at the bottom of the queue" : undefined} onClick={() => handleReorderQueue(index, 1)}>
                     <ArrowDown className="h-3.5 w-3.5" />
                   </Button>
                   <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => handleRemoveFromQueue(key)}>

--- a/src/components/settings/diagnostics/SystemStatePanel.tsx
+++ b/src/components/settings/diagnostics/SystemStatePanel.tsx
@@ -103,7 +103,7 @@ export default function SystemStatePanel() {
                     size="sm"
                     className="h-6 gap-1 text-[10px] text-destructive hover:text-destructive"
                     onClick={() => handleClear(key, { status: "idle" })}
-                    disabled={clearing === key}
+                    disabled={clearing === key} title={clearing === key ? "Clearing…" : undefined}
                   >
                     {clearing === key ? (
                       <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/hooks/useAgentStatus.ts
+++ b/src/hooks/useAgentStatus.ts
@@ -159,7 +159,7 @@ export function useAgentStatus(): AgentStatusInfo {
     queryKey: ["agent-status"],
     queryFn: fetchAgentStatus,
     staleTime: Infinity,
-    initialData: DEFAULT_STATUS,
+    placeholderData: DEFAULT_STATUS,
   });
 
   useEffect(() => {
@@ -175,5 +175,5 @@ export function useAgentStatus(): AgentStatusInfo {
     return () => { supabase.removeChannel(channel); };
   }, [queryClient]);
 
-  return data;
+  return data ?? DEFAULT_STATUS;
 }

--- a/src/hooks/useScanProgress.ts
+++ b/src/hooks/useScanProgress.ts
@@ -115,7 +115,7 @@ export function useScanProgress(): ScanProgress & { pollNow: () => void } {
     queryKey: ["scan-progress"],
     queryFn: fetchScanProgress,
     staleTime: Infinity,
-    initialData: DEFAULT_PROGRESS,
+    placeholderData: DEFAULT_PROGRESS,
   });
 
   useEffect(() => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -68,6 +68,20 @@ export default function LoginPage() {
     }
   };
 
+  const handleMicrosoftSignIn = async () => {
+    setError(null);
+    const { error } = await externalSupabase.auth.signInWithOAuth({
+      provider: "azure",
+      options: {
+        scopes: "email",
+        redirectTo: "https://popdam.designflow.app",
+      },
+    });
+    if (error) {
+      setError(error.message || "Microsoft sign-in failed");
+    }
+  };
+
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -140,6 +154,22 @@ export default function LoginPage() {
                 />
               </svg>
               Continue with Google
+            </Button>
+
+            {/* Microsoft OAuth */}
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleMicrosoftSignIn}
+              type="button"
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 21 21">
+                <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+                <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+                <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+                <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+              </svg>
+              Continue with Microsoft
             </Button>
 
             <div className="relative">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -118,6 +118,7 @@ function AgentUpdateControls({ agentId, agentName }: { agentId: string; agentNam
         className="gap-1.5 text-xs h-7"
         onClick={handleCheck}
         disabled={checking || applying}
+        title={applying ? "Applying update…" : checking ? "Checking for updates…" : undefined}
       >
         {checking ? <Loader2 className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
         Check for Update
@@ -139,7 +140,7 @@ function AgentUpdateControls({ agentId, agentName }: { agentId: string; agentNam
             size="sm"
             className="gap-1.5 text-xs h-7"
             onClick={handleApply}
-            disabled={applying}
+            disabled={applying} title={applying ? "Applying update…" : undefined}
           >
             {applying ? <Loader2 className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
             {applying ? "Updating..." : "Apply Update"}
@@ -153,7 +154,7 @@ function AgentUpdateControls({ agentId, agentName }: { agentId: string; agentNam
           size="sm"
           className="gap-1.5 text-xs h-7 text-muted-foreground"
           onClick={handleApply}
-          disabled={applying}
+          disabled={applying} title={applying ? "Applying update…" : undefined}
         >
           {applying ? <Loader2 className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
           {applying ? "Updating..." : "Force Update"}
@@ -243,7 +244,7 @@ function AgentStatusSection() {
           {anyForceStopped ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="default" size="sm" onClick={() => resumeMutation.mutate()} disabled={resumeMutation.isPending} className="gap-1.5">
+                <Button variant="default" size="sm" onClick={() => resumeMutation.mutate()} disabled={resumeMutation.isPending} title={resumeMutation.isPending ? "Resuming…" : undefined} className="gap-1.5">
                   <Play className="h-3.5 w-3.5" /> Resume Scanning
                 </Button>
               </TooltipTrigger>
@@ -252,7 +253,7 @@ function AgentStatusSection() {
           ) : (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="destructive" size="sm" onClick={() => { if (confirm("Stop all agents and block ingestion?")) stopMutation.mutate(); }} disabled={stopMutation.isPending} className="gap-1.5">
+                <Button variant="destructive" size="sm" onClick={() => { if (confirm("Stop all agents and block ingestion?")) stopMutation.mutate(); }} disabled={stopMutation.isPending} title={stopMutation.isPending ? "Stopping all agents…" : undefined} className="gap-1.5">
                   <StopCircle className="h-3.5 w-3.5" /> Stop All
                 </Button>
               </TooltipTrigger>
@@ -261,7 +262,7 @@ function AgentStatusSection() {
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="outline" size="sm" onClick={() => { if (confirm("Reset scan state to idle? This clears any stuck scan.")) resetScanMutation.mutate(); }} disabled={resetScanMutation.isPending} className="gap-1.5">
+              <Button variant="outline" size="sm" onClick={() => { if (confirm("Reset scan state to idle? This clears any stuck scan.")) resetScanMutation.mutate(); }} disabled={resetScanMutation.isPending} title={resetScanMutation.isPending ? "Resetting scan state…" : undefined} className="gap-1.5">
                 <RotateCcw className="h-3.5 w-3.5" /> Reset Scan State
               </Button>
             </TooltipTrigger>
@@ -468,6 +469,7 @@ function AgentKeySection() {
           <Button
             onClick={() => generateMutation.mutate()}
             disabled={!agentName.trim() || generateMutation.isPending}
+            title={!agentName.trim() ? "Enter an agent name first" : generateMutation.isPending ? "Generating key…" : undefined}
             size="sm"
           >
             Generate
@@ -578,7 +580,7 @@ function PathTesterSection() {
             onChange={(e) => setInputPath(e.target.value)}
             className="font-mono text-xs"
           />
-          <Button size="sm" onClick={handleTest} disabled={!inputPath.trim()}>Test</Button>
+          <Button size="sm" onClick={handleTest} disabled={!inputPath.trim()} title={!inputPath.trim() ? "Enter a path to test first" : undefined}>Test</Button>
         </div>
         {result && (
           <div className={`text-xs font-mono rounded-md p-3 space-y-1 ${result.valid ? "bg-[hsl(var(--success)/0.1)] border border-[hsl(var(--success)/0.3)]" : "bg-destructive/10 border border-destructive/30"}`}>
@@ -691,7 +693,7 @@ function InvitationSection() {
             <option value="user">User</option>
             <option value="admin">Admin</option>
           </select>
-          <Button size="sm" onClick={() => inviteMutation.mutate()} disabled={!email.trim()}>
+          <Button size="sm" onClick={() => inviteMutation.mutate()} disabled={!email.trim()} title={!email.trim() ? "Enter an email address first" : undefined}>
             Invite
           </Button>
         </div>
@@ -717,6 +719,7 @@ function InvitationSection() {
                         variant="outline" size="sm" className="h-6 text-xs gap-1"
                         onClick={() => handleResend(inv.id as string, inv.email as string)}
                         disabled={resendingId === inv.id}
+                        title={resendingId === inv.id ? "Sending invitation…" : undefined}
                       >
                         {resendingId === inv.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
                         Resend

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -85,7 +85,7 @@ function ConnectivityTest({ agentName }: { agentName: string }) {
     <div className="border border-border rounded-md p-3 space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-xs font-semibold text-muted-foreground">Connectivity Test</span>
-        <Button size="sm" variant="outline" onClick={check} disabled={status === "checking"} className="gap-1.5 text-xs">
+        <Button size="sm" variant="outline" onClick={check} disabled={status === "checking"} title={status === "checking" ? "Checking connection…" : undefined} className="gap-1.5 text-xs">
           {status === "checking" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Wifi className="h-3 w-3" />}
           Test Connection
         </Button>
@@ -388,7 +388,7 @@ services:
                   <Button
                     size="sm"
                     onClick={() => generateKeyMutation.mutate()}
-                    disabled={generateKeyMutation.isPending}
+                    disabled={generateKeyMutation.isPending} title={generateKeyMutation.isPending ? "Generating key…" : undefined}
                   >
                     Generate Agent Key for "{state.agentName}"
                   </Button>
@@ -431,7 +431,7 @@ services:
         <Button
           variant="outline"
           onClick={() => setStep(Math.max(0, step - 1))}
-          disabled={step === 0}
+          disabled={step === 0} title={step === 0 ? "Already on the first step" : undefined}
           className="gap-1"
         >
           <ChevronLeft className="h-4 w-4" /> Previous
@@ -439,7 +439,7 @@ services:
         {step < STEPS.length - 1 && (
           <Button
             onClick={() => setStep(step + 1)}
-            disabled={!canAdvance()}
+            disabled={!canAdvance()} title={!canAdvance() ? "Complete the required fields on this step first" : undefined}
             className="gap-1"
           >
             Next <ChevronRight className="h-4 w-4" />

--- a/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
+++ b/supabase/migrations/20260325231907_agent_registrations_authenticated_read.sql
@@ -1,0 +1,8 @@
+-- Allow all authenticated users to read agent_registrations so the
+-- library page and AppHeader can show agent status (bridgeStatus) via
+-- the Supabase JS client. Write operations remain admin-only.
+CREATE POLICY "authenticated users can read agent_registrations"
+  ON public.agent_registrations
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
Every button that is disabled now has a `title` attribute explaining why — hover to see the reason instead of just seeing a greyed-out control.

## Changes
- **Library panels**: `AssetDetailPanel`, `StyleGroupDetailPanel` — AI tagging, sync, image add buttons
- **Settings tabs**: `WorkerManagementTab`, `WindowsAgentTab`, `ApisTab`, `FileHygieneTab`, `TiffHygieneTab`, `ErpEnrichmentTab`, `StyleGuideCrawlTab` — all mutation pending states + prerequisite messages
- **Diagnostics**: `DatabaseInspector`, `QueueManagerDialog`, `SystemStatePanel`
- **Pages**: `SettingsPage`, `SetupPage`
- **`ScanProgressPanel`**: Stop button

## Tooltip categories
1. **Operation in progress**: "Saving…", "Scanning…", "Sync in progress…" etc.
2. **Prerequisite missing**: "Enter a path first", "Enable this integration first", "No unsaved changes"
3. **Dependency not met**: "Requires a thumbnail", "Configure storage setting first"