### PR TITLE
Report inaccessible style guide crawl roots + warn in UI

### DIFF
--- a/apps/bridge-agent/package.json
+++ b/apps/bridge-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popdam-bridge-agent",
 
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "PopDAM Bridge Agent — NAS filesystem scanner, thumbnail generator, and cloud sync worker",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge-agent/src/api-client.ts
+++ b/apps/bridge-agent/src/api-client.ts
@@ -322,6 +322,7 @@ export async function completeStyleGuideCrawl(
   done: boolean,
   totalFiles?: number,
   error?: string,
+  inaccessibleRoots?: string[],
 ): Promise<void> {
   await callApi("complete-style-guide-crawl", {
     run_id: runId,
@@ -329,5 +330,6 @@ export async function completeStyleGuideCrawl(
     done,
     total_files: totalFiles,
     error,
+    inaccessible_roots: inaccessibleRoots?.length ? inaccessibleRoots : undefined,
   });
 }

--- a/apps/bridge-agent/src/style-guide-crawler.ts
+++ b/apps/bridge-agent/src/style-guide-crawler.ts
@@ -162,6 +162,7 @@ export async function crawlStyleGuides(roots: string[]): Promise<void> {
 
   let totalFiles = 0;
   let batch: StyleGuideFileRecord[] = [];
+  const inaccessibleRoots: string[] = [];
 
   try {
     for (const root of roots) {
@@ -173,12 +174,14 @@ export async function crawlStyleGuides(roots: string[]): Promise<void> {
         const s = await lstat(resolvedRoot);
         if (!s.isDirectory()) {
           logger.warn("Style guide crawl: root is not a directory", { root });
+          inaccessibleRoots.push(root);
           continue;
         }
       } catch (e) {
         logger.warn("Style guide crawl: root inaccessible", {
           root, error: (e as Error).message,
         });
+        inaccessibleRoots.push(root);
         continue;
       }
 
@@ -197,14 +200,14 @@ export async function crawlStyleGuides(roots: string[]): Promise<void> {
     }
 
     // Send final batch
-    await api.completeStyleGuideCrawl(runId, batch, true, totalFiles);
-    logger.info("Style guide crawl completed", { totalFiles });
+    await api.completeStyleGuideCrawl(runId, batch, true, totalFiles, undefined, inaccessibleRoots);
+    logger.info("Style guide crawl completed", { totalFiles, inaccessibleRoots });
 
   } catch (e) {
     const errorMsg = (e as Error).message;
     logger.error("Style guide crawl failed", { error: errorMsg });
     try {
-      await api.completeStyleGuideCrawl(runId, [], true, totalFiles, errorMsg);
+      await api.completeStyleGuideCrawl(runId, [], true, totalFiles, errorMsg, inaccessibleRoots);
     } catch (e2) {
       logger.error("Style guide crawl: failed to report error", { error: (e2 as Error).message });
     }

--- a/src/components/settings/StyleGuideCrawlTab.tsx
+++ b/src/components/settings/StyleGuideCrawlTab.tsx
@@ -122,6 +122,21 @@ export default function StyleGuideCrawlTab() {
             </div>
           )}
 
+          {/* Inaccessible roots warning */}
+          {(() => {
+            const inaccessible = (request?.inaccessible_roots || lastRun?.inaccessible_roots) as string[] | undefined;
+            if (!inaccessible?.length) return null;
+            return (
+              <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md p-2 space-y-1">
+                <div className="font-medium">⚠ Path not accessible in container — volume mount missing?</div>
+                {inaccessible.map((p) => (
+                  <div key={p} className="font-mono">{p}</div>
+                ))}
+                <div className="text-muted-foreground">Add the corresponding volume mount to your docker-compose.yml and recreate the container.</div>
+              </div>
+            );
+          })()}
+
           {/* Results */}
           <div className="grid grid-cols-3 gap-3">
             <div className="bg-muted/50 rounded-md p-3 text-center">

--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -2366,6 +2366,7 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
   const done = body.done === true;
   const totalFiles = body.total_files as number | undefined;
   const crawlError = body.error as string | undefined;
+  const inaccessibleRoots = (body.inaccessible_roots as string[]) || [];
 
   if (!runId) return err("run_id is required");
 
@@ -2406,11 +2407,12 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
         error_message: crawlError,
         completed_at: new Date().toISOString(),
         files_found: totalFiles ?? 0,
+        ...(inaccessibleRoots.length ? { inaccessible_roots: inaccessibleRoots } : {}),
       }).eq("id", runId);
 
       await db.from("admin_config").upsert({
         key: "STYLE_GUIDE_CRAWL_REQUEST",
-        value: { status: "failed", error: crawlError, completed_at: new Date().toISOString() },
+        value: { status: "failed", error: crawlError, completed_at: new Date().toISOString(), inaccessible_roots: inaccessibleRoots },
         updated_at: new Date().toISOString(),
       });
     } else {
@@ -2418,6 +2420,7 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
         status: "completed",
         completed_at: new Date().toISOString(),
         files_found: totalFiles ?? 0,
+        ...(inaccessibleRoots.length ? { inaccessible_roots: inaccessibleRoots } : {}),
       }).eq("id", runId);
 
       // Mark stale files
@@ -2441,7 +2444,7 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
 
       await db.from("admin_config").upsert({
         key: "STYLE_GUIDE_CRAWL_REQUEST",
-        value: { status: "completed", completed_at: new Date().toISOString(), files_found: totalFiles },
+        value: { status: "completed", completed_at: new Date().toISOString(), files_found: totalFiles, inaccessible_roots: inaccessibleRoots },
         updated_at: new Date().toISOString(),
       });
     }

--- a/supabase/migrations/20260326040635_style_guide_crawl_runs_inaccessible_roots.sql
+++ b/supabase/migrations/20260326040635_style_guide_crawl_runs_inaccessible_roots.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.style_guide_crawl_runs
+  ADD COLUMN IF NOT EXISTS inaccessible_roots text[] DEFAULT NULL;


### PR DESCRIPTION
When a configured style guide root path isn't accessible inside the container (missing volume mount in docker-compose.yml), the crawl previously completed silently with 0 files and showed "Idle" — giving no indication anything was wrong.

## Changes
- **bridge-agent 1.4.2**: crawler tracks inaccessible roots and includes them in the `complete-style-guide-crawl` API call
- **agent-api**: stores `inaccessible_roots` on the crawl run record and in `STYLE_GUIDE_CRAWL_REQUEST`
- **DB migration**: adds `inaccessible_roots text[]` column to `style_guide_crawl_runs`
- **StyleGuideCrawlTab**: shows an amber warning box listing inaccessible paths with a hint to check docker-compose.yml volume mounts