### PR TITLE
fix: assets updated_at column + admin impersonation + /data volume persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
-import { ImpersonationProvider } from "@/hooks/useImpersonation";
+import { ImpersonationProvider } from "@/contexts/ImpersonationContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AppLayout from "@/components/AppLayout";
 import Index from "./pages/Index";

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,10 +1,28 @@
 import { Outlet } from "react-router-dom";
 import AppHeader from "@/components/AppHeader";
+import { useImpersonation } from "@/contexts/ImpersonationContext";
 
 export default function AppLayout() {
+  const { impersonating, stopImpersonation } = useImpersonation();
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <AppHeader />
+      {impersonating && (
+        <div className="sticky top-14 z-40 flex items-center justify-between bg-amber-500 px-4 py-1.5 text-xs text-white">
+          <span>
+            Viewing as <strong>{impersonating.email}</strong>
+            {" — "}
+            {impersonating.isAdmin ? "Admin" : "Non-admin"} view
+          </span>
+          <button
+            onClick={stopImpersonation}
+            className="rounded bg-white/20 px-2 py-0.5 font-medium transition-colors hover:bg-white/30"
+          >
+            Exit impersonation
+          </button>
+        </div>
+      )}
       <main className="flex-1">
         <Outlet />
       </main>

--- a/src/contexts/ImpersonationContext.tsx
+++ b/src/contexts/ImpersonationContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+export interface ImpersonatedUser {
+  id: string;
+  email: string;
+  isAdmin: boolean;
+}
+
+interface ImpersonationContextType {
+  impersonating: ImpersonatedUser | null;
+  startImpersonation: (user: ImpersonatedUser) => void;
+  stopImpersonation: () => void;
+}
+
+const ImpersonationContext = createContext<ImpersonationContextType>({
+  impersonating: null,
+  startImpersonation: () => {},
+  stopImpersonation: () => {},
+});
+
+export function ImpersonationProvider({ children }: { children: ReactNode }) {
+  const [impersonating, setImpersonating] = useState<ImpersonatedUser | null>(null);
+
+  return (
+    <ImpersonationContext.Provider
+      value={{
+        impersonating,
+        startImpersonation: setImpersonating,
+        stopImpersonation: () => setImpersonating(null),
+      }}
+    >
+      {children}
+    </ImpersonationContext.Provider>
+  );
+}
+
+export function useImpersonation() {
+  return useContext(ImpersonationContext);
+}

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,18 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
-import { useImpersonation } from "@/hooks/useImpersonation";
+import { useImpersonation } from "@/contexts/ImpersonationContext";
 
 /**
  * Returns whether the current user has the 'admin' role.
- * Queries user_roles table directly (RLS must allow reads for own rows).
- * If impersonation is active, masks the admin role client-side.
+ * When impersonating, returns the impersonated user's role instead.
  */
 export function useIsAdmin() {
   const { user } = useAuth();
-  const { impersonatedRole } = useImpersonation();
+  const { impersonating } = useImpersonation();
 
-  const { data: isRealAdmin = false, isLoading } = useQuery({
+  const { data: isAdmin = false, isLoading } = useQuery({
     queryKey: ["is-admin", user?.id],
     queryFn: async () => {
       if (!user) return false;
@@ -25,11 +24,13 @@ export function useIsAdmin() {
       if (error) return false;
       return !!data;
     },
-    enabled: !!user,
+    enabled: !!user && impersonating === null,
     staleTime: 5 * 60 * 1000,
   });
 
-  const isAdmin = impersonatedRole === "member" ? false : isRealAdmin;
+  if (impersonating !== null) {
+    return { isAdmin: impersonating.isAdmin, isLoading: false };
+  }
 
-  return { isAdmin, isRealAdmin, isLoading };
+  return { isAdmin, isLoading };
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
-import { Settings as SettingsIcon, RefreshCw, Activity, Key, UserPlus, Copy, Check, Trash2, MapPin, BarChart3, Play, StopCircle, RotateCcw, Download, Loader2, CheckCircle2 } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Settings as SettingsIcon, RefreshCw, Activity, Key, UserPlus, Copy, Check, Trash2, MapPin, BarChart3, Play, StopCircle, RotateCcw, Download, Loader2, CheckCircle2, Eye, Users } from "lucide-react";
+import { useImpersonation } from "@/contexts/ImpersonationContext";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { parseInputPath, type NasConfig } from "@/lib/path-utils";
@@ -623,6 +624,68 @@ function PathTesterSection() {
   );
 }
 
+// ── User List + Impersonation ────────────────────────────────────────
+
+interface UserRecord {
+  id: string;
+  email: string;
+  full_name: string | null;
+  created_at: string;
+  isAdmin: boolean;
+}
+
+function UsersSection() {
+  const { call } = useAdminApi();
+  const { startImpersonation } = useImpersonation();
+  const navigate = useNavigate();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin-users"],
+    queryFn: () => call("list-users").then((r) => r.users as UserRecord[]),
+    staleTime: 60_000,
+  });
+
+  const handleImpersonate = (u: UserRecord) => {
+    startImpersonation({ id: u.id, email: u.email, isAdmin: u.isAdmin });
+    navigate("/library");
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Users className="h-4 w-4" /> Active Users
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
+        {!isLoading && (!data || data.length === 0) && (
+          <p className="text-xs text-muted-foreground">No users found.</p>
+        )}
+        <div className="space-y-2">
+          {data?.map((u) => (
+            <div key={u.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{u.email}</p>
+                <p className="text-xs text-muted-foreground">{u.isAdmin ? "Admin" : "User"}</p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="ml-3 shrink-0 gap-1.5"
+                onClick={() => handleImpersonate(u)}
+              >
+                <Eye className="h-3.5 w-3.5" />
+                View as
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 // ── Invitation Manager ──────────────────────────────────────────────
 
 function InvitationSection() {
@@ -998,7 +1061,8 @@ export default function SettingsPage() {
         </TabsContent>
 
         {/* ── Users ── */}
-        <TabsContent value="users">
+        <TabsContent value="users" className="space-y-4">
+          <UsersSection />
           <InvitationSection />
         </TabsContent>
 

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -445,6 +445,30 @@ async function handleRevokeInvite(body: Record<string, unknown>) {
   return json({ ok: true });
 }
 
+// ── Route: list-users ───────────────────────────────────────────────
+
+async function handleListUsers() {
+  const db = serviceClient();
+  const { data, error } = await db
+    .from("profiles")
+    .select("user_id, email, full_name, created_at, user_roles(role)")
+    .order("created_at", { ascending: false });
+
+  if (error) return err(error.message, 500);
+
+  return json({
+    ok: true,
+    users: (data ?? []).map((u) => ({
+      id: u.user_id,
+      email: u.email,
+      full_name: u.full_name,
+      created_at: u.created_at,
+      isAdmin: Array.isArray(u.user_roles) &&
+        (u.user_roles as { role: string }[]).some((r) => r.role === "admin"),
+    })),
+  });
+}
+
 // ── Route: run-query ─────────────────────────────────────────────────
 
 async function handleRunQuery(body: Record<string, unknown>) {
@@ -808,6 +832,8 @@ serve(async (req: Request) => {
         return await handleListInvites();
       case "revoke-invite":
         return await handleRevokeInvite(body);
+      case "list-users":
+        return await handleListUsers();
 
       // ── Agents (from agent-handlers.ts) ──
       case "generate-agent-key":

--- a/supabase/migrations/20260326212850_assets_add_updated_at_column.sql
+++ b/supabase/migrations/20260326212850_assets_add_updated_at_column.sql
@@ -1,0 +1,7 @@
+-- The 2026-03-23 migration (assets_updated_at_trigger) added a trigger that sets
+-- NEW.updated_at = now() on every UPDATE, but forgot to add the column.
+-- This caused every asset UPDATE to fail with "record NEW has no field updated_at"
+-- for 3 days, breaking scan ingestion, thumbnail updates, and all other writes.
+
+ALTER TABLE public.assets
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();


### PR DESCRIPTION
## Critical fix: assets table broken for 3 days

The `assets_updated_at_trigger` migration (2026-03-23) added a BEFORE UPDATE trigger that sets `NEW.updated_at = now()`, but never added the `updated_at` column. Every single UPDATE on any asset row has been failing with 500 "record NEW has no field updated_at" since then — scan ingestion, thumbnail writes, ERP enrichment, all broken.

**Fix:** `ADD COLUMN updated_at timestamptz DEFAULT now()` (already applied to DB).

## Other changes

- **Admin impersonation** (`Settings → Users`): "View as" button lets admins preview the app as any user without logging out. Amber banner persists while impersonating. One click to exit.
- **Synology `/data` volume**: Added `- /volume1/docker/popdam/data:/data` to `deploy/synology/docker-compose.yml` so agent key survives container rebuilds (prevents 401 key churn).
- **Style guide crawl reset**: Reset `STYLE_GUIDE_CRAWL_REQUEST` to `pending` in DB so agent re-runs the crawl now that the 500 bug is fixed.
- **`scripts/nas-ssh.sh`**: Helper script for future SSH-based NAS management from Claude Code sessions.
- **`admin-api list-users`**: New endpoint returning all users + roles, used by impersonation UI.

https://claude.ai/code/session_01S43tunVNBrVbMihnSjpSpp