### PR TITLE
fix: use is_deleted instead of is_active on assets table

### DIFF
--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -785,7 +785,7 @@ async function handleTriggerPdfTextSample() {
     .from("assets")
     .select("id, relative_path, filename")
     .eq("file_type", "pdf")
-    .eq("is_active", true)
+    .eq("is_deleted", false)
     .limit(25);
 
   if (error) return err(error.message, 500);


### PR DESCRIPTION
The `assets` table has no `is_active` column, causing a 500 error when running the PDF Text Extraction Sample. Fixed by replacing `.eq("is_active", true)` with `.eq("is_deleted", false)` in `handleTriggerPdfTextSample()`.