### PR TITLE
feat: move PDF text extraction to windows agent

### DIFF
--- a/apps/windows-agent/package-lock.json
+++ b/apps/windows-agent/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@popdam/windows-agent",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.600.0",
         "@popdam/path-filters": "file:../../packages/path-filters",
         "dotenv": "^16.4.5",
+        "mupdf": "^1.26.0",
+        "pdf-parse": "^1.1.1",
         "sharp": "^0.33.0"
       },
       "devDependencies": {
@@ -2613,6 +2615,18 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
+    "node_modules/mupdf": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mupdf/-/mupdf-1.27.0.tgz",
+      "integrity": "sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ==",
+      "license": "AGPL-3.0-or-later"
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
@@ -2626,6 +2640,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/apps/windows-agent/package.json
+++ b/apps/windows-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {
@@ -12,6 +12,8 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@popdam/path-filters": "file:../../packages/path-filters",
     "dotenv": "^16.4.5",
+    "mupdf": "^1.26.0",
+    "pdf-parse": "^1.1.1",
     "sharp": "^0.33.0"
   },
   "devDependencies": {

--- a/apps/windows-agent/src/api-client.ts
+++ b/apps/windows-agent/src/api-client.ts
@@ -62,6 +62,8 @@ export interface WindowsHeartbeatResponse {
   };
   commands?: {
     trigger_update?: boolean;
+    trigger_pdf_text_sample?: boolean;
+    pdf_text_sample_assets?: unknown[];
   };
 }
 
@@ -126,6 +128,10 @@ export async function completeRender(
   });
 }
 
+
+export async function completePdfTextSample(results: unknown[]): Promise<void> {
+  await callApi("complete-pdf-text-sample", { results });
+}
 
 /**
  * Update an asset's fields (e.g. pdf_page2_url after PDF rendering).

--- a/apps/windows-agent/src/index.ts
+++ b/apps/windows-agent/src/index.ts
@@ -27,11 +27,13 @@ import { shouldSkipPath, resetSkipWarnings } from "@popdam/path-filters";
 import { startJanitor } from "./janitor";
 import path from "node:path";
 import { writeFile } from "node:fs/promises";
+import { runPdfTextSample, type PdfSampleAsset } from "./pdf-text-sampler";
 
 // ── State ───────────────────────────────────────────────────────
 
 let agentId: string = "";
 let activeJobs = 0;
+let isSamplingPdfText = false;
 let lastError: string | undefined;
 let jobsCompleted = 0;
 let jobsFailed = 0;
@@ -254,6 +256,17 @@ function startHeartbeat() {
         update_error: updateState.lastError,
       });
       applyCloudConfig(response);
+
+      // PDF text extraction sample
+      if (response.commands?.trigger_pdf_text_sample && !isSamplingPdfText) {
+        const assets = (response.commands.pdf_text_sample_assets as PdfSampleAsset[]) || [];
+        const mountRoot = cloudNasMountPath.trim() || `\\\\${cloudNasHost}\\${cloudNasShare}`;
+        isSamplingPdfText = true;
+        logger.info("PDF text sample requested via heartbeat", { count: assets.length });
+        runPdfTextSample(assets, mountRoot).finally(() => {
+          isSamplingPdfText = false;
+        });
+      }
 
       // Check if cloud requests immediate update
       if (response.commands?.trigger_update) {

--- a/apps/windows-agent/src/pdf-text-sampler.ts
+++ b/apps/windows-agent/src/pdf-text-sampler.ts
@@ -1,0 +1,132 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "./logger";
+import * as api from "./api-client";
+
+// pdf-parse is CJS-compatible
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string; numpages: number }>;
+
+// mupdf is pure ESM. TypeScript's "moduleResolution: node" can't resolve its exports
+// field, so we bypass static analysis with new Function to get a dynamic import.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dynamicImport = new Function("m", "return import(m)") as (m: string) => Promise<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _mupdf: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getMupdf(): Promise<any> {
+  if (!_mupdf) _mupdf = await dynamicImport("mupdf");
+  return _mupdf;
+}
+
+export interface PdfSampleAsset {
+  id: string;
+  relative_path: string;
+  filename: string;
+}
+
+export interface PdfTextSampleResult {
+  asset_id: string;
+  filename: string;
+  relative_path: string;
+  extraction_method: "pdf_text" | "likely_scanned" | "failed";
+  extracted_text: string | null;
+  page_count: number | null;
+  char_count: number;
+  extraction_error: string | null;
+}
+
+export async function runPdfTextSample(
+  assets: PdfSampleAsset[],
+  mountRoot: string,
+): Promise<void> {
+  if (assets.length === 0) {
+    logger.info("PDF text sample: no assets to process");
+    return;
+  }
+
+  logger.info("PDF text sample: starting", { count: assets.length, mountRoot });
+
+  const results: PdfTextSampleResult[] = [];
+
+  for (const asset of assets) {
+    const fullPath = join(mountRoot, asset.relative_path);
+    let result: PdfTextSampleResult;
+
+    try {
+      const buffer = await readFile(fullPath);
+
+      let rawText: string;
+      let numPages: number;
+
+      try {
+        const parsed = await Promise.race([
+          pdfParse(buffer),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("pdf-parse timed out after 30s")), 30_000)
+          ),
+        ]);
+        rawText = parsed.text || "";
+        numPages = parsed.numpages;
+      } catch (primaryErr) {
+        logger.warn("PDF text sample: pdf-parse failed, trying mupdf fallback", {
+          filename: asset.filename,
+          error: (primaryErr as Error).message,
+        });
+        const mupdf = await getMupdf();
+        const doc = mupdf.Document.openDocument(buffer, "application/pdf");
+        numPages = doc.countPages();
+        const parts: string[] = [];
+        for (let p = 0; p < numPages; p++) {
+          parts.push(doc.loadPage(p).toStructuredText("preserve-whitespace").asText());
+        }
+        rawText = parts.join("\n");
+      }
+
+      const text = rawText.trim();
+      const charCount = text.length;
+      const method: PdfTextSampleResult["extraction_method"] =
+        charCount >= 100 ? "pdf_text" : charCount > 0 ? "likely_scanned" : "failed";
+
+      result = {
+        asset_id: asset.id,
+        filename: asset.filename,
+        relative_path: asset.relative_path,
+        extraction_method: method,
+        extracted_text: charCount > 0 ? text : null,
+        page_count: numPages || null,
+        char_count: charCount,
+        extraction_error: null,
+      };
+
+      logger.info("PDF text sample: extracted", {
+        filename: asset.filename,
+        method,
+        chars: charCount,
+        pages: numPages,
+      });
+    } catch (e) {
+      const errMsg = (e as Error).message;
+      logger.warn("PDF text sample: extraction failed", {
+        filename: asset.filename,
+        path: fullPath,
+        error: errMsg,
+      });
+      result = {
+        asset_id: asset.id,
+        filename: asset.filename,
+        relative_path: asset.relative_path,
+        extraction_method: "failed",
+        extracted_text: null,
+        page_count: null,
+        char_count: 0,
+        extraction_error: errMsg.slice(0, 500),
+      };
+    }
+
+    results.push(result);
+  }
+
+  await api.completePdfTextSample(results);
+  logger.info("PDF text sample: completed", { total: results.length });
+}

--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -443,8 +443,8 @@ async function handleHeartbeat(
         return crawlReq.status === "pending" || (crawlReq.status === "claimed" && crawlReq.claimed_by === agentId);
       })(),
       ...(() => {
-        // Deliver PDF text sample command if pending and agent is a bridge
-        if (agentType !== "bridge") return {};
+        // Deliver PDF text sample command if pending and agent is a windows-render
+        if (agentType !== "windows-render") return {};
         const sampleReq = configMap.PDF_TEXT_SAMPLE_REQUEST as Record<string, unknown> | undefined;
         if (!sampleReq || sampleReq.status !== "pending") return {};
         return {


### PR DESCRIPTION
The Windows agent has faster/more direct NAS access than the Synology bridge container, so PDF text extraction should run there instead.

**Changes:**
- `agent-api`: delivers `trigger_pdf_text_sample` to `windows-render` agents (was `bridge`)
- `windows-agent`: new `pdf-text-sampler.ts` with pdf-parse primary + mupdf fallback (same logic as bridge agent); wired into heartbeat loop
- `windows-agent`: adds `completePdfTextSample` to api-client and new commands fields to heartbeat type
- mupdf loaded via `new Function` dynamic import (needed because the Windows agent is CommonJS and mupdf is pure ESM, and `moduleResolution: node` can't resolve its exports field statically)

Bumps windows-agent to 0.7.0.