### PR TITLE
fix: lazy-load pdf-parse and mupdf to prevent OTA crash on startup

### DIFF
--- a/apps/windows-agent/package.json
+++ b/apps/windows-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/apps/windows-agent/src/pdf-text-sampler.ts
+++ b/apps/windows-agent/src/pdf-text-sampler.ts
@@ -3,20 +3,19 @@ import { join } from "node:path";
 import { logger } from "./logger";
 import * as api from "./api-client";
 
-// pdf-parse is CJS-compatible
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string; numpages: number }>;
-
-// mupdf is pure ESM. TypeScript's "moduleResolution: node" can't resolve its exports
-// field, so we bypass static analysis with new Function to get a dynamic import.
+// pdf-parse and mupdf are only available after a full installer run, not OTA dist updates.
+// Load them lazily inside the function so a missing module never crashes startup.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dynamicImport = new Function("m", "return import(m)") as (m: string) => Promise<any>;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _mupdf: any = null;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getMupdf(): Promise<any> {
-  if (!_mupdf) _mupdf = await dynamicImport("mupdf");
-  return _mupdf;
+function tryRequire(mod: string): any | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(mod);
+  } catch {
+    return null;
+  }
 }
 
 export interface PdfSampleAsset {
@@ -60,6 +59,8 @@ export async function runPdfTextSample(
       let numPages: number;
 
       try {
+        const pdfParse = tryRequire("pdf-parse") as ((buf: Buffer) => Promise<{ text: string; numpages: number }>) | null;
+        if (!pdfParse) throw new Error("pdf-parse not installed");
         const parsed = await Promise.race([
           pdfParse(buffer),
           new Promise<never>((_, reject) =>
@@ -73,7 +74,9 @@ export async function runPdfTextSample(
           filename: asset.filename,
           error: (primaryErr as Error).message,
         });
-        const mupdf = await getMupdf();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mupdf: any = await dynamicImport("mupdf").catch(() => null);
+        if (!mupdf) throw new Error("mupdf not installed");
         const doc = mupdf.Document.openDocument(buffer, "application/pdf");
         numPages = doc.countPages();
         const parts: string[] = [];


### PR DESCRIPTION
OTA dist updates replace only `dist/*.js`, not `node_modules/`. The top-level `require("pdf-parse")` in `pdf-text-sampler.ts` was crashing the agent immediately on startup after an OTA update because `pdf-parse` wasn't in `node_modules/`. This caused a crash loop and the update mechanism to appear broken ("fetch failed").

Fix: moved both `require("pdf-parse")` and the mupdf dynamic import inside the function body with null-checks (`tryRequire`). The module now loads cleanly even when those packages aren't installed — PDF extraction will gracefully fail with a per-asset error on agents that haven't been fully reinstalled with the new dependencies.

Bumps windows-agent to 0.7.1.