### PR TITLE
feat: PDF text extraction follows Windows Render Policy, adds OCR + AI vision fallbacks

### DIFF
--- a/apps/bridge-agent/package.json
+++ b/apps/bridge-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popdam-bridge-agent",
 
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "PopDAM Bridge Agent — NAS filesystem scanner, thumbnail generator, and cloud sync worker",
   "type": "module",
   "main": "dist/index.js",
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.600.0",
+    "@anthropic-ai/sdk": "^0.30.0",
     "mupdf": "^1.26.0",
     "pdf-parse": "^1.1.1",
+    "tesseract.js": "^5.0.0",
     "@popdam/path-filters": "file:../../packages/path-filters",
     "@supabase/supabase-js": "^2.46.0",
     "sharp": "0.33.4"

--- a/apps/bridge-agent/src/api-client.ts
+++ b/apps/bridge-agent/src/api-client.ts
@@ -134,6 +134,7 @@ export interface HeartbeatResponse {
     windows_healthy?: boolean;
     pending_render_jobs?: number;
     style_guide_scanning?: { roots: string[] };
+    ai?: { anthropic_api_key?: string };
   };
   commands?: {
     force_scan: boolean;

--- a/apps/bridge-agent/src/index.ts
+++ b/apps/bridge-agent/src/index.ts
@@ -100,6 +100,7 @@ let cloudBatchSize: number | null = null;
 let cloudConcurrency: number | null = null;
 let cloudScanMinDate: string | null = null;
 let cloudStyleGuideRoots: string[] = [];
+let cloudAnthropicApiKey = "";
 
 // Auto-scan state
 let autoScanEnabled = false;
@@ -206,7 +207,7 @@ async function sendHeartbeat() {
       const assets = (response.commands.pdf_text_sample_assets as PdfSampleAsset[]) || [];
       isSamplingPdfText = true;
       logger.info("PDF text sample requested via heartbeat", { count: assets.length });
-      runPdfTextSample(assets, config.nasContainerMountRoot).finally(() => {
+      runPdfTextSample(assets, config.nasContainerMountRoot, cloudAnthropicApiKey || undefined).finally(() => {
         isSamplingPdfText = false;
       });
     }
@@ -271,6 +272,7 @@ interface CloudConfig {
   windows_healthy?: boolean;
   pending_render_jobs?: number;
   style_guide_scanning?: { roots: string[] };
+  ai?: { anthropic_api_key?: string };
 }
 
 function applyCloudConfig(cfg: CloudConfig) {
@@ -338,6 +340,11 @@ function applyCloudConfig(cfg: CloudConfig) {
   // Update style guide scanning roots
   if (cfg.style_guide_scanning?.roots) {
     cloudStyleGuideRoots = cfg.style_guide_scanning.roots;
+  }
+
+  // Update Anthropic API key
+  if (cfg.ai?.anthropic_api_key) {
+    cloudAnthropicApiKey = cfg.ai.anthropic_api_key;
   }
 }
 

--- a/apps/bridge-agent/src/pdf-text-sampler.ts
+++ b/apps/bridge-agent/src/pdf-text-sampler.ts
@@ -2,11 +2,20 @@
  * PDF Text Sampler
  *
  * Takes a list of PDF assets (passed from admin-api via heartbeat config),
- * reads each from the NAS filesystem, attempts text extraction via pdf-parse,
- * and classifies the result:
- *   'pdf_text'       — ≥100 chars extracted (native text PDF)
- *   'likely_scanned' — >0 but <100 chars (probably a scanned image PDF)
- *   'failed'         — 0 chars or threw an error
+ * reads each from the NAS filesystem, and attempts text extraction via a
+ * cascade of methods:
+ *
+ *   1. pdf-parse  — native text extraction (30s timeout)
+ *   2. mupdf      — alternative text extraction if pdf-parse fails
+ *   3. OCR        — tesseract.js on a rendered page image (if text is sparse/absent)
+ *   4. AI vision  — Claude claude-haiku-4-5-20251001 on a rendered page image (if OCR also fails)
+ *
+ * Extraction method classification:
+ *   'pdf_text'       — ≥100 chars from pdf-parse or mupdf text extraction
+ *   'ocr_text'       — ≥100 chars from OCR
+ *   'ai_vision'      — text extracted via AI vision
+ *   'likely_scanned' — >0 but <100 chars after all methods
+ *   'failed'         — 0 chars or all methods threw errors
  *
  * Results are POSTed to agent-api complete-pdf-text-sample.
  */
@@ -14,7 +23,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { logger } from "./logger.js";
-import { config } from "./config.js";
 import * as api from "./api-client.js";
 
 // pdf-parse is a CJS module; use createRequire for ESM compatibility
@@ -24,6 +32,8 @@ const require = createRequire(import.meta.url);
 const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string; numpages: number }>;
 
 import mupdf from "mupdf";
+import { createWorker } from "tesseract.js";
+import Anthropic from "@anthropic-ai/sdk";
 
 export interface PdfSampleAsset {
   id: string;
@@ -35,7 +45,7 @@ export interface PdfTextSampleResult {
   asset_id: string;
   filename: string;
   relative_path: string;
-  extraction_method: "pdf_text" | "likely_scanned" | "failed";
+  extraction_method: "pdf_text" | "likely_scanned" | "failed" | "ocr_text" | "ai_vision";
   extracted_text: string | null;
   page_count: number | null;
   char_count: number;
@@ -45,6 +55,7 @@ export interface PdfTextSampleResult {
 export async function runPdfTextSample(
   assets: PdfSampleAsset[],
   mountRoot: string,
+  anthropicApiKey?: string,
 ): Promise<void> {
   if (assets.length === 0) {
     logger.info("PDF text sample: no assets to process");
@@ -62,9 +73,11 @@ export async function runPdfTextSample(
     try {
       const buffer = await readFile(fullPath);
 
-      let rawText: string;
-      let numPages: number;
+      let rawText = "";
+      let numPages: number | null = null;
+      let mupdfDoc: ReturnType<typeof mupdf.Document.openDocument> | null = null;
 
+      // ── Step 1: pdf-parse (primary text extraction) ──────────────────
       try {
         const parsed = await Promise.race([
           pdfParse(buffer),
@@ -75,41 +88,180 @@ export async function runPdfTextSample(
         rawText = parsed.text || "";
         numPages = parsed.numpages;
       } catch (primaryErr) {
-        logger.warn("PDF text sample: pdf-parse failed, trying mupdf fallback", {
+        logger.warn("PDF text sample: pdf-parse failed, trying mupdf text extraction", {
           filename: asset.filename,
           error: (primaryErr as Error).message,
         });
-        const doc = mupdf.Document.openDocument(buffer, "application/pdf");
-        numPages = doc.countPages();
-        const parts: string[] = [];
-        for (let p = 0; p < numPages; p++) {
-          parts.push(doc.loadPage(p).toStructuredText("preserve-whitespace").asText());
+
+        // ── Step 2: mupdf text extraction (fallback) ──────────────────
+        try {
+          mupdfDoc = mupdf.Document.openDocument(buffer, "application/pdf");
+          numPages = mupdfDoc.countPages();
+          const parts: string[] = [];
+          for (let p = 0; p < numPages; p++) {
+            parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
+          }
+          rawText = parts.join("\n");
+        } catch (mupdfErr) {
+          logger.warn("PDF text sample: mupdf text extraction also failed", {
+            filename: asset.filename,
+            error: (mupdfErr as Error).message,
+          });
         }
-        rawText = parts.join("\n");
       }
 
       const text = rawText.trim();
       const charCount = text.length;
-      const method: PdfTextSampleResult["extraction_method"] =
-        charCount >= 100 ? "pdf_text" : charCount > 0 ? "likely_scanned" : "failed";
 
-      result = {
-        asset_id: asset.id,
-        filename: asset.filename,
-        relative_path: asset.relative_path,
-        extraction_method: method,
-        extracted_text: charCount > 0 ? text : null,
-        page_count: numPages || null,
-        char_count: charCount,
-        extraction_error: null,
-      };
+      if (charCount >= 100) {
+        // Sufficient native text — done
+        result = {
+          asset_id: asset.id,
+          filename: asset.filename,
+          relative_path: asset.relative_path,
+          extraction_method: "pdf_text",
+          extracted_text: text,
+          page_count: numPages,
+          char_count: charCount,
+          extraction_error: null,
+        };
+        logger.info("PDF text sample: extracted via text", {
+          filename: asset.filename,
+          chars: charCount,
+          pages: numPages,
+        });
+      } else {
+        // Sparse or no text — try OCR then AI vision
 
-      logger.info("PDF text sample: extracted", {
-        filename: asset.filename,
-        method,
-        chars: charCount,
-        pages: numPages,
-      });
+        // ── Step 3: render page 0 to PNG via mupdf (used by OCR + AI) ──
+        let pngBuffer: Buffer | null = null;
+        try {
+          if (!mupdfDoc) {
+            mupdfDoc = mupdf.Document.openDocument(buffer, "application/pdf");
+            numPages = mupdfDoc.countPages();
+          }
+          const page = mupdfDoc.loadPage(0);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const pixmap = page.toPixmap([2, 0, 0, 2, 0, 0] as any, (mupdf as any).ColorSpace.DeviceRGB, false);
+          pngBuffer = Buffer.from(pixmap.asPNG() as Uint8Array);
+        } catch (renderErr) {
+          logger.warn("PDF text sample: mupdf page render failed", {
+            filename: asset.filename,
+            error: (renderErr as Error).message,
+          });
+        }
+
+        // ── Step 4: OCR via tesseract.js ──────────────────────────────
+        let ocrText = "";
+        if (pngBuffer) {
+          try {
+            const worker = await createWorker("eng");
+            const ocrResult = await worker.recognize(pngBuffer);
+            await worker.terminate();
+            ocrText = ocrResult.data.text.trim();
+          } catch (ocrErr) {
+            logger.warn("PDF text sample: OCR failed", {
+              filename: asset.filename,
+              error: (ocrErr as Error).message,
+            });
+          }
+        }
+
+        if (ocrText.length >= 100) {
+          result = {
+            asset_id: asset.id,
+            filename: asset.filename,
+            relative_path: asset.relative_path,
+            extraction_method: "ocr_text",
+            extracted_text: ocrText,
+            page_count: numPages,
+            char_count: ocrText.length,
+            extraction_error: null,
+          };
+          logger.info("PDF text sample: extracted via OCR", {
+            filename: asset.filename,
+            chars: ocrText.length,
+          });
+        } else {
+          // ── Step 5: AI vision via Claude ──────────────────────────────
+          let aiText = "";
+          let aiErrMsg = "";
+          if (pngBuffer && anthropicApiKey) {
+            try {
+              const anthropic = new Anthropic({ apiKey: anthropicApiKey });
+              const aiResponse = await anthropic.messages.create({
+                model: "claude-haiku-4-5-20251001",
+                max_tokens: 2048,
+                messages: [{
+                  role: "user",
+                  content: [
+                    {
+                      type: "image",
+                      source: {
+                        type: "base64",
+                        media_type: "image/png",
+                        data: pngBuffer.toString("base64"),
+                      },
+                    },
+                    {
+                      type: "text",
+                      text: "Extract all text from this document page. Return only the raw extracted text with no commentary.",
+                    },
+                  ],
+                }],
+              });
+              const first = aiResponse.content[0];
+              if (first.type === "text") {
+                aiText = first.text.trim();
+              }
+            } catch (aiErr) {
+              aiErrMsg = (aiErr as Error).message;
+              logger.warn("PDF text sample: AI vision failed", {
+                filename: asset.filename,
+                error: aiErrMsg,
+              });
+            }
+          }
+
+          if (aiText.length > 0) {
+            result = {
+              asset_id: asset.id,
+              filename: asset.filename,
+              relative_path: asset.relative_path,
+              extraction_method: "ai_vision",
+              extracted_text: aiText,
+              page_count: numPages,
+              char_count: aiText.length,
+              extraction_error: null,
+            };
+            logger.info("PDF text sample: extracted via AI vision", {
+              filename: asset.filename,
+              chars: aiText.length,
+            });
+          } else {
+            // All methods exhausted — use best available text
+            const finalText = ocrText.length > 0 ? ocrText : text;
+            const finalCount = finalText.length;
+            const method: "pdf_text" | "likely_scanned" | "failed" =
+              finalCount >= 100 ? "pdf_text" : finalCount > 0 ? "likely_scanned" : "failed";
+            result = {
+              asset_id: asset.id,
+              filename: asset.filename,
+              relative_path: asset.relative_path,
+              extraction_method: method,
+              extracted_text: finalCount > 0 ? finalText : null,
+              page_count: numPages,
+              char_count: finalCount,
+              extraction_error: aiErrMsg ? aiErrMsg.slice(0, 500) : null,
+            };
+            logger.info("PDF text sample: minimal/no text after all methods", {
+              filename: asset.filename,
+              method,
+              chars: finalCount,
+            });
+          }
+        }
+      }
     } catch (e) {
       const errMsg = (e as Error).message;
       logger.warn("PDF text sample: extraction failed", {

--- a/apps/windows-agent/package.json
+++ b/apps/windows-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {
@@ -12,9 +12,11 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@popdam/path-filters": "file:../../packages/path-filters",
     "dotenv": "^16.4.5",
+    "@anthropic-ai/sdk": "^0.30.0",
     "mupdf": "^1.26.0",
     "pdf-parse": "^1.1.1",
-    "sharp": "^0.33.0"
+    "sharp": "^0.33.0",
+    "tesseract.js": "^5.0.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/apps/windows-agent/src/api-client.ts
+++ b/apps/windows-agent/src/api-client.ts
@@ -59,6 +59,9 @@ export interface WindowsHeartbeatResponse {
       nas_mount_path?: string;
       render_concurrency?: number;
     };
+    ai?: {
+      anthropic_api_key?: string;
+    };
   };
   commands?: {
     trigger_update?: boolean;

--- a/apps/windows-agent/src/index.ts
+++ b/apps/windows-agent/src/index.ts
@@ -62,6 +62,7 @@ let cloudSpacesKey = config.doSpacesKey;
 let cloudSpacesSecret = config.doSpacesSecret;
 let cloudNasUsername = "";
 let cloudNasPassword = "";
+let cloudAnthropicApiKey = "";
 
 // ── Pairing ─────────────────────────────────────────────────────
 
@@ -240,6 +241,11 @@ async function applyCloudConfig(response: api.WindowsHeartbeatResponse) {
       spacesSecret: cloudSpacesSecret ? "(set)" : "(missing)",
     });
   }
+
+  // Update Anthropic API key
+  if (response.config?.ai?.anthropic_api_key) {
+    cloudAnthropicApiKey = response.config.ai.anthropic_api_key;
+  }
 }
 
 function startHeartbeat() {
@@ -263,7 +269,7 @@ function startHeartbeat() {
         const mountRoot = cloudNasMountPath.trim() || `\\\\${cloudNasHost}\\${cloudNasShare}`;
         isSamplingPdfText = true;
         logger.info("PDF text sample requested via heartbeat", { count: assets.length });
-        runPdfTextSample(assets, mountRoot).finally(() => {
+        runPdfTextSample(assets, mountRoot, cloudAnthropicApiKey || undefined).finally(() => {
           isSamplingPdfText = false;
         });
       }

--- a/apps/windows-agent/src/pdf-text-sampler.ts
+++ b/apps/windows-agent/src/pdf-text-sampler.ts
@@ -3,8 +3,9 @@ import { join } from "node:path";
 import { logger } from "./logger";
 import * as api from "./api-client";
 
-// pdf-parse and mupdf are only available after a full installer run, not OTA dist updates.
-// Load them lazily inside the function so a missing module never crashes startup.
+// pdf-parse, mupdf, tesseract.js, and @anthropic-ai/sdk are only available after
+// a full installer run, not OTA dist updates. Load them lazily inside the function
+// so a missing module never crashes startup.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dynamicImport = new Function("m", "return import(m)") as (m: string) => Promise<any>;
 
@@ -28,7 +29,7 @@ export interface PdfTextSampleResult {
   asset_id: string;
   filename: string;
   relative_path: string;
-  extraction_method: "pdf_text" | "likely_scanned" | "failed";
+  extraction_method: "pdf_text" | "likely_scanned" | "failed" | "ocr_text" | "ai_vision";
   extracted_text: string | null;
   page_count: number | null;
   char_count: number;
@@ -38,6 +39,7 @@ export interface PdfTextSampleResult {
 export async function runPdfTextSample(
   assets: PdfSampleAsset[],
   mountRoot: string,
+  anthropicApiKey?: string,
 ): Promise<void> {
   if (assets.length === 0) {
     logger.info("PDF text sample: no assets to process");
@@ -55,9 +57,14 @@ export async function runPdfTextSample(
     try {
       const buffer = await readFile(fullPath);
 
-      let rawText: string;
-      let numPages: number;
+      let rawText = "";
+      let numPages: number | null = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let mupdfRef: any = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let mupdfDoc: any = null;
 
+      // ── Step 1: pdf-parse (primary text extraction) ──────────────────
       try {
         const pdfParse = tryRequire("pdf-parse") as ((buf: Buffer) => Promise<{ text: string; numpages: number }>) | null;
         if (!pdfParse) throw new Error("pdf-parse not installed");
@@ -70,44 +77,192 @@ export async function runPdfTextSample(
         rawText = parsed.text || "";
         numPages = parsed.numpages;
       } catch (primaryErr) {
-        logger.warn("PDF text sample: pdf-parse failed, trying mupdf fallback", {
+        logger.warn("PDF text sample: pdf-parse failed, trying mupdf text extraction", {
           filename: asset.filename,
           error: (primaryErr as Error).message,
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const mupdf: any = await dynamicImport("mupdf").catch(() => null);
-        if (!mupdf) throw new Error("mupdf not installed");
-        const doc = mupdf.Document.openDocument(buffer, "application/pdf");
-        numPages = doc.countPages();
-        const parts: string[] = [];
-        for (let p = 0; p < numPages; p++) {
-          parts.push(doc.loadPage(p).toStructuredText("preserve-whitespace").asText());
+
+        // ── Step 2: mupdf text extraction (fallback) ──────────────────
+        try {
+          mupdfRef = await dynamicImport("mupdf").catch(() => null);
+          if (!mupdfRef) throw new Error("mupdf not installed");
+          mupdfDoc = mupdfRef.Document.openDocument(buffer, "application/pdf");
+          numPages = mupdfDoc.countPages();
+          const parts: string[] = [];
+          for (let p = 0; p < numPages; p++) {
+            parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
+          }
+          rawText = parts.join("\n");
+        } catch (mupdfErr) {
+          logger.warn("PDF text sample: mupdf text extraction also failed", {
+            filename: asset.filename,
+            error: (mupdfErr as Error).message,
+          });
         }
-        rawText = parts.join("\n");
       }
 
       const text = rawText.trim();
       const charCount = text.length;
-      const method: PdfTextSampleResult["extraction_method"] =
-        charCount >= 100 ? "pdf_text" : charCount > 0 ? "likely_scanned" : "failed";
 
-      result = {
-        asset_id: asset.id,
-        filename: asset.filename,
-        relative_path: asset.relative_path,
-        extraction_method: method,
-        extracted_text: charCount > 0 ? text : null,
-        page_count: numPages || null,
-        char_count: charCount,
-        extraction_error: null,
-      };
+      if (charCount >= 100) {
+        // Sufficient native text — done
+        result = {
+          asset_id: asset.id,
+          filename: asset.filename,
+          relative_path: asset.relative_path,
+          extraction_method: "pdf_text",
+          extracted_text: text,
+          page_count: numPages,
+          char_count: charCount,
+          extraction_error: null,
+        };
+        logger.info("PDF text sample: extracted via text", {
+          filename: asset.filename,
+          chars: charCount,
+          pages: numPages,
+        });
+      } else {
+        // Sparse or no text — try OCR then AI vision
 
-      logger.info("PDF text sample: extracted", {
-        filename: asset.filename,
-        method,
-        chars: charCount,
-        pages: numPages,
-      });
+        // ── Step 3: render page 0 to PNG via mupdf (used by OCR + AI) ──
+        let pngBuffer: Buffer | null = null;
+        try {
+          if (!mupdfRef) mupdfRef = await dynamicImport("mupdf").catch(() => null);
+          if (mupdfRef) {
+            if (!mupdfDoc) {
+              mupdfDoc = mupdfRef.Document.openDocument(buffer, "application/pdf");
+              numPages = mupdfDoc.countPages();
+            }
+            const page = mupdfDoc.loadPage(0);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const pixmap = page.toPixmap([2, 0, 0, 2, 0, 0] as any, mupdfRef.ColorSpace.DeviceRGB, false);
+            pngBuffer = Buffer.from(pixmap.asPNG() as Uint8Array);
+          }
+        } catch (renderErr) {
+          logger.warn("PDF text sample: mupdf page render failed", {
+            filename: asset.filename,
+            error: (renderErr as Error).message,
+          });
+        }
+
+        // ── Step 4: OCR via tesseract.js ──────────────────────────────
+        let ocrText = "";
+        if (pngBuffer) {
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const tesseractLib: any = await dynamicImport("tesseract.js").catch(() => null);
+            if (!tesseractLib) throw new Error("tesseract.js not installed");
+            const worker = await tesseractLib.createWorker("eng");
+            const ocrResult = await worker.recognize(pngBuffer);
+            await worker.terminate();
+            ocrText = (ocrResult.data.text as string).trim();
+          } catch (ocrErr) {
+            logger.warn("PDF text sample: OCR failed", {
+              filename: asset.filename,
+              error: (ocrErr as Error).message,
+            });
+          }
+        }
+
+        if (ocrText.length >= 100) {
+          result = {
+            asset_id: asset.id,
+            filename: asset.filename,
+            relative_path: asset.relative_path,
+            extraction_method: "ocr_text",
+            extracted_text: ocrText,
+            page_count: numPages,
+            char_count: ocrText.length,
+            extraction_error: null,
+          };
+          logger.info("PDF text sample: extracted via OCR", {
+            filename: asset.filename,
+            chars: ocrText.length,
+          });
+        } else {
+          // ── Step 5: AI vision via Claude ──────────────────────────────
+          let aiText = "";
+          let aiErrMsg = "";
+          if (pngBuffer && anthropicApiKey) {
+            try {
+              const AnthropicLib = tryRequire("@anthropic-ai/sdk");
+              if (!AnthropicLib) throw new Error("@anthropic-ai/sdk not installed");
+              const Anthropic = AnthropicLib.default ?? AnthropicLib;
+              const anthropic = new Anthropic({ apiKey: anthropicApiKey });
+              const aiResponse = await anthropic.messages.create({
+                model: "claude-haiku-4-5-20251001",
+                max_tokens: 2048,
+                messages: [{
+                  role: "user",
+                  content: [
+                    {
+                      type: "image",
+                      source: {
+                        type: "base64",
+                        media_type: "image/png",
+                        data: pngBuffer.toString("base64"),
+                      },
+                    },
+                    {
+                      type: "text",
+                      text: "Extract all text from this document page. Return only the raw extracted text with no commentary.",
+                    },
+                  ],
+                }],
+              });
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const first = aiResponse.content[0] as any;
+              if (first && first.type === "text") {
+                aiText = (first.text as string).trim();
+              }
+            } catch (aiErr) {
+              aiErrMsg = (aiErr as Error).message;
+              logger.warn("PDF text sample: AI vision failed", {
+                filename: asset.filename,
+                error: aiErrMsg,
+              });
+            }
+          }
+
+          if (aiText.length > 0) {
+            result = {
+              asset_id: asset.id,
+              filename: asset.filename,
+              relative_path: asset.relative_path,
+              extraction_method: "ai_vision",
+              extracted_text: aiText,
+              page_count: numPages,
+              char_count: aiText.length,
+              extraction_error: null,
+            };
+            logger.info("PDF text sample: extracted via AI vision", {
+              filename: asset.filename,
+              chars: aiText.length,
+            });
+          } else {
+            // All methods exhausted — use best available text
+            const finalText = ocrText.length > 0 ? ocrText : text;
+            const finalCount = finalText.length;
+            const method: "pdf_text" | "likely_scanned" | "failed" =
+              finalCount >= 100 ? "pdf_text" : finalCount > 0 ? "likely_scanned" : "failed";
+            result = {
+              asset_id: asset.id,
+              filename: asset.filename,
+              relative_path: asset.relative_path,
+              extraction_method: method,
+              extracted_text: finalCount > 0 ? finalText : null,
+              page_count: numPages,
+              char_count: finalCount,
+              extraction_error: aiErrMsg ? aiErrMsg.slice(0, 500) : null,
+            };
+            logger.info("PDF text sample: minimal/no text after all methods", {
+              filename: asset.filename,
+              method,
+              chars: finalCount,
+            });
+          }
+        }
+      }
     } catch (e) {
       const errMsg = (e as Error).message;
       logger.warn("PDF text sample: extraction failed", {

--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -103,6 +103,7 @@ const HEARTBEAT_CONFIG_KEYS = [
   "HYGIENE_SCAN_REQUEST",
   "STYLE_GUIDE_SCAN_ROOTS",
   "STYLE_GUIDE_CRAWL_REQUEST",
+  "ANTHROPIC_API_KEY",
 ];
 
 async function handleHeartbeat(
@@ -426,6 +427,9 @@ async function handleHeartbeat(
       style_guide_scanning: {
         roots: (configMap.STYLE_GUIDE_SCAN_ROOTS as string[]) || [],
       },
+      ai: {
+        anthropic_api_key: (configMap.ANTHROPIC_API_KEY as string) || "",
+      },
     },
     commands: {
       force_scan: forceScan,
@@ -443,10 +447,27 @@ async function handleHeartbeat(
         return crawlReq.status === "pending" || (crawlReq.status === "claimed" && crawlReq.claimed_by === agentId);
       })(),
       ...(() => {
-        // Deliver PDF text sample command if pending and agent is a windows-render
-        if (agentType !== "windows-render") return {};
+        // Deliver PDF text sample command based on Windows Render Policy.
+        // primary/shared (or no policy) → windows-render handles it
+        // fallback_only → bridge handles it
+        // If windows is required-healthy but unhealthy → fall back to bridge
         const sampleReq = configMap.PDF_TEXT_SAMPLE_REQUEST as Record<string, unknown> | undefined;
         if (!sampleReq || sampleReq.status !== "pending") return {};
+
+        const policy = (configMap.WINDOWS_RENDER_POLICY as Record<string, unknown> | null) || null;
+        const policyMode = (policy?.mode as string) || "primary";
+        const requireWindowsHealthy = policy?.require_windows_healthy === true;
+
+        let targetAgentType: string;
+        if (policyMode === "fallback_only") {
+          targetAgentType = "bridge";
+        } else if (requireWindowsHealthy && !windowsHealthy) {
+          targetAgentType = "bridge"; // windows should handle but is unhealthy
+        } else {
+          targetAgentType = "windows-render";
+        }
+
+        if (agentType !== targetAgentType) return {};
         return {
           trigger_pdf_text_sample: true,
           pdf_text_sample_assets: (sampleReq.assets as unknown[]) || [],


### PR DESCRIPTION
## Summary

- **Routing**: PDF text sample command now follows `WINDOWS_RENDER_POLICY` instead of being hardcoded to windows-render. `primary`/`shared` (or no policy) → windows-render; `fallback_only` → bridge; health-gated via `require_windows_healthy`
- **OCR fallback**: When text extraction yields <100 chars, mupdf renders page 0 to PNG at 2x scale and tesseract.js OCRs it → `ocr_text`
- **AI vision fallback**: If OCR also fails/sparse, Claude Haiku analyzes the rendered page image → `ai_vision`
- **Config**: `ANTHROPIC_API_KEY` now passed from Supabase admin_config to agents via `ai.anthropic_api_key` in heartbeat response
- **Versions**: windows-agent v0.8.0, bridge-agent v1.6.0

New `extraction_method` values: `ocr_text`, `ai_vision` (no DB migration needed — column has no CHECK constraint)

https://claude.ai/code/session_01WKjhiKYJ2TETeSxGNBDDpt