### PR TITLE
feat: drop pdf-parse, mupdf primary extractor, AI vision from model catalog

### DIFF
--- a/apps/bridge-agent/package.json
+++ b/apps/bridge-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popdam-bridge-agent",
 
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "PopDAM Bridge Agent — NAS filesystem scanner, thumbnail generator, and cloud sync worker",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,6 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@anthropic-ai/sdk": "^0.30.0",
     "mupdf": "^1.26.0",
-    "pdf-parse": "^1.1.1",
     "tesseract.js": "^5.0.0",
     "@popdam/path-filters": "file:../../packages/path-filters",
     "@supabase/supabase-js": "^2.46.0",

--- a/apps/bridge-agent/src/api-client.ts
+++ b/apps/bridge-agent/src/api-client.ts
@@ -134,7 +134,12 @@ export interface HeartbeatResponse {
     windows_healthy?: boolean;
     pending_render_jobs?: number;
     style_guide_scanning?: { roots: string[] };
-    ai?: { anthropic_api_key?: string };
+    ai?: {
+      anthropic_api_key?: string;
+      google_ai_api_key?: string;
+      models?: Array<{ id: string; provider: string; apiModel: string; capabilities: string[] }>;
+      pdf_extraction?: { ai_vision_model_id?: string } | null;
+    };
   };
   commands?: {
     force_scan: boolean;

--- a/apps/bridge-agent/src/index.ts
+++ b/apps/bridge-agent/src/index.ts
@@ -25,7 +25,7 @@ import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { startRealtimeWatcher } from "./realtime-watcher.js";
 import { crawlStyleGuides } from "./style-guide-crawler.js";
-import { runPdfTextSample, type PdfSampleAsset } from "./pdf-text-sampler.js";
+import { runPdfTextSample, type PdfSampleAsset, type AiModelDef } from "./pdf-text-sampler.js";
 
 // ── State ───────────────────────────────────────────────────────
 
@@ -101,6 +101,9 @@ let cloudConcurrency: number | null = null;
 let cloudScanMinDate: string | null = null;
 let cloudStyleGuideRoots: string[] = [];
 let cloudAnthropicApiKey = "";
+let cloudGoogleAiApiKey = "";
+let cloudAiModels: AiModelDef[] = [];
+let cloudPdfExtractionConfig: { ai_vision_model_id: string } | null = null;
 
 // Auto-scan state
 let autoScanEnabled = false;
@@ -207,7 +210,12 @@ async function sendHeartbeat() {
       const assets = (response.commands.pdf_text_sample_assets as PdfSampleAsset[]) || [];
       isSamplingPdfText = true;
       logger.info("PDF text sample requested via heartbeat", { count: assets.length });
-      runPdfTextSample(assets, config.nasContainerMountRoot, cloudAnthropicApiKey || undefined).finally(() => {
+      runPdfTextSample(assets, config.nasContainerMountRoot, {
+        models: cloudAiModels,
+        pdf_extraction: cloudPdfExtractionConfig,
+        googleApiKey: cloudGoogleAiApiKey,
+        anthropicApiKey: cloudAnthropicApiKey,
+      }).finally(() => {
         isSamplingPdfText = false;
       });
     }
@@ -272,7 +280,12 @@ interface CloudConfig {
   windows_healthy?: boolean;
   pending_render_jobs?: number;
   style_guide_scanning?: { roots: string[] };
-  ai?: { anthropic_api_key?: string };
+  ai?: {
+    anthropic_api_key?: string;
+    google_ai_api_key?: string;
+    models?: Array<{ id: string; provider: string; apiModel: string; capabilities: string[] }>;
+    pdf_extraction?: { ai_vision_model_id?: string } | null;
+  };
 }
 
 function applyCloudConfig(cfg: CloudConfig) {
@@ -342,9 +355,14 @@ function applyCloudConfig(cfg: CloudConfig) {
     cloudStyleGuideRoots = cfg.style_guide_scanning.roots;
   }
 
-  // Update Anthropic API key
-  if (cfg.ai?.anthropic_api_key) {
-    cloudAnthropicApiKey = cfg.ai.anthropic_api_key;
+  // Update AI config
+  if (cfg.ai) {
+    if (cfg.ai.anthropic_api_key) cloudAnthropicApiKey = cfg.ai.anthropic_api_key;
+    if (cfg.ai.google_ai_api_key) cloudGoogleAiApiKey = cfg.ai.google_ai_api_key;
+    if (Array.isArray(cfg.ai.models) && cfg.ai.models.length > 0) cloudAiModels = cfg.ai.models as AiModelDef[];
+    if (cfg.ai.pdf_extraction !== undefined) {
+      cloudPdfExtractionConfig = (cfg.ai.pdf_extraction as { ai_vision_model_id: string } | null) ?? null;
+    }
   }
 }
 

--- a/apps/bridge-agent/src/pdf-text-sampler.ts
+++ b/apps/bridge-agent/src/pdf-text-sampler.ts
@@ -1,35 +1,24 @@
 /**
  * PDF Text Sampler
  *
- * Takes a list of PDF assets (passed from admin-api via heartbeat config),
- * reads each from the NAS filesystem, and attempts text extraction via a
- * cascade of methods:
+ * Reads each PDF asset from the NAS and extracts text using a cascade:
  *
- *   1. pdf-parse  — native text extraction (30s timeout)
- *   2. mupdf      — alternative text extraction if pdf-parse fails
- *   3. OCR        — tesseract.js on a rendered page image (if text is sparse/absent)
- *   4. AI vision  — Claude claude-haiku-4-5-20251001 on a rendered page image (if OCR also fails)
+ *   1. mupdf  — native text extraction (primary; robust C library)
+ *   2. OCR    — tesseract.js on a mupdf-rendered page image (scanned PDFs)
+ *   3. AI     — vision model from PDF_EXTRACTION_CONFIG/AI_MODELS catalog
  *
- * Extraction method classification:
- *   'pdf_text'       — ≥100 chars from pdf-parse or mupdf text extraction
+ * Extraction method values:
+ *   'pdf_text'       — ≥100 chars from mupdf text extraction
  *   'ocr_text'       — ≥100 chars from OCR
- *   'ai_vision'      — text extracted via AI vision
+ *   'ai_vision'      — text extracted by AI vision model
  *   'likely_scanned' — >0 but <100 chars after all methods
  *   'failed'         — 0 chars or all methods threw errors
- *
- * Results are POSTed to agent-api complete-pdf-text-sample.
  */
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { logger } from "./logger.js";
 import * as api from "./api-client.js";
-
-// pdf-parse is a CJS module; use createRequire for ESM compatibility
-import { createRequire } from "node:module";
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string; numpages: number }>;
 
 import mupdf from "mupdf";
 import { createWorker } from "tesseract.js";
@@ -39,6 +28,20 @@ export interface PdfSampleAsset {
   id: string;
   relative_path: string;
   filename: string;
+}
+
+export interface AiModelDef {
+  id: string;
+  provider: string;
+  apiModel: string;
+  capabilities: string[];
+}
+
+export interface AiConfig {
+  models: AiModelDef[];
+  pdf_extraction: { ai_vision_model_id: string } | null;
+  googleApiKey: string;
+  anthropicApiKey: string;
 }
 
 export interface PdfTextSampleResult {
@@ -52,10 +55,83 @@ export interface PdfTextSampleResult {
   extraction_error: string | null;
 }
 
+// ── AI vision call (provider-agnostic, resolved from model catalog) ──────────
+
+async function callAiVision(pngBuffer: Buffer, aiConfig: AiConfig): Promise<string> {
+  const modelId = aiConfig.pdf_extraction?.ai_vision_model_id;
+  if (!modelId) return "";
+
+  const modelDef = aiConfig.models.find((m) => m.id === modelId);
+  if (!modelDef) {
+    logger.warn("PDF text sample: ai vision model not found in catalog", { modelId });
+    return "";
+  }
+  if (!modelDef.capabilities.includes("vision")) {
+    logger.warn("PDF text sample: selected model has no vision capability", { modelId });
+    return "";
+  }
+
+  const base64 = pngBuffer.toString("base64");
+
+  if (modelDef.provider === "google") {
+    if (!aiConfig.googleApiKey) {
+      logger.warn("PDF text sample: GOOGLE_AI_API_KEY not configured");
+      return "";
+    }
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelDef.apiModel}:generateContent?key=${aiConfig.googleApiKey}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(60_000),
+      body: JSON.stringify({
+        contents: [{
+          role: "user",
+          parts: [
+            { inlineData: { mimeType: "image/png", data: base64 } },
+            { text: "Extract all text from this document page. Return only the raw extracted text with no commentary." },
+          ],
+        }],
+      }),
+    });
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Gemini API ${res.status}: ${errText.slice(0, 200)}`);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = await res.json() as any;
+    return (data?.candidates?.[0]?.content?.parts?.[0]?.text as string || "").trim();
+
+  } else if (modelDef.provider === "anthropic") {
+    if (!aiConfig.anthropicApiKey) {
+      logger.warn("PDF text sample: ANTHROPIC_API_KEY not configured");
+      return "";
+    }
+    const anthropic = new Anthropic({ apiKey: aiConfig.anthropicApiKey });
+    const aiResponse = await anthropic.messages.create({
+      model: modelDef.apiModel,
+      max_tokens: 2048,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: base64 } },
+          { type: "text", text: "Extract all text from this document page. Return only the raw extracted text with no commentary." },
+        ],
+      }],
+    });
+    const first = aiResponse.content[0];
+    return (first.type === "text" ? first.text : "").trim();
+  }
+
+  logger.warn("PDF text sample: unsupported ai vision provider", { provider: modelDef.provider });
+  return "";
+}
+
+// ── Main sampler ──────────────────────────────────────────────────────────────
+
 export async function runPdfTextSample(
   assets: PdfSampleAsset[],
   mountRoot: string,
-  anthropicApiKey?: string,
+  aiConfig: AiConfig,
 ): Promise<void> {
   if (assets.length === 0) {
     logger.info("PDF text sample: no assets to process");
@@ -77,44 +153,26 @@ export async function runPdfTextSample(
       let numPages: number | null = null;
       let mupdfDoc: ReturnType<typeof mupdf.Document.openDocument> | null = null;
 
-      // ── Step 1: pdf-parse (primary text extraction) ──────────────────
+      // ── Step 1: mupdf text extraction (primary) ─────────────────────────────
       try {
-        const parsed = await Promise.race([
-          pdfParse(buffer),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("pdf-parse timed out after 30s")), 30_000)
-          ),
-        ]);
-        rawText = parsed.text || "";
-        numPages = parsed.numpages;
-      } catch (primaryErr) {
-        logger.warn("PDF text sample: pdf-parse failed, trying mupdf text extraction", {
-          filename: asset.filename,
-          error: (primaryErr as Error).message,
-        });
-
-        // ── Step 2: mupdf text extraction (fallback) ──────────────────
-        try {
-          mupdfDoc = mupdf.Document.openDocument(buffer, "application/pdf");
-          numPages = mupdfDoc.countPages();
-          const parts: string[] = [];
-          for (let p = 0; p < numPages; p++) {
-            parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
-          }
-          rawText = parts.join("\n");
-        } catch (mupdfErr) {
-          logger.warn("PDF text sample: mupdf text extraction also failed", {
-            filename: asset.filename,
-            error: (mupdfErr as Error).message,
-          });
+        mupdfDoc = mupdf.Document.openDocument(buffer, "application/pdf");
+        numPages = mupdfDoc.countPages();
+        const parts: string[] = [];
+        for (let p = 0; p < numPages; p++) {
+          parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
         }
+        rawText = parts.join("\n");
+      } catch (mupdfErr) {
+        logger.warn("PDF text sample: mupdf text extraction failed", {
+          filename: asset.filename,
+          error: (mupdfErr as Error).message,
+        });
       }
 
       const text = rawText.trim();
       const charCount = text.length;
 
       if (charCount >= 100) {
-        // Sufficient native text — done
         result = {
           asset_id: asset.id,
           filename: asset.filename,
@@ -125,15 +183,15 @@ export async function runPdfTextSample(
           char_count: charCount,
           extraction_error: null,
         };
-        logger.info("PDF text sample: extracted via text", {
+        logger.info("PDF text sample: extracted via mupdf text", {
           filename: asset.filename,
           chars: charCount,
           pages: numPages,
         });
       } else {
-        // Sparse or no text — try OCR then AI vision
+        // Sparse or no text — render page 0 for OCR + AI vision
 
-        // ── Step 3: render page 0 to PNG via mupdf (used by OCR + AI) ──
+        // ── Step 2: render page 0 to PNG via mupdf ────────────────────────────
         let pngBuffer: Buffer | null = null;
         try {
           if (!mupdfDoc) {
@@ -151,7 +209,7 @@ export async function runPdfTextSample(
           });
         }
 
-        // ── Step 4: OCR via tesseract.js ──────────────────────────────
+        // ── Step 3: OCR via tesseract.js ──────────────────────────────────────
         let ocrText = "";
         if (pngBuffer) {
           try {
@@ -183,37 +241,12 @@ export async function runPdfTextSample(
             chars: ocrText.length,
           });
         } else {
-          // ── Step 5: AI vision via Claude ──────────────────────────────
+          // ── Step 4: AI vision ─────────────────────────────────────────────
           let aiText = "";
           let aiErrMsg = "";
-          if (pngBuffer && anthropicApiKey) {
+          if (pngBuffer) {
             try {
-              const anthropic = new Anthropic({ apiKey: anthropicApiKey });
-              const aiResponse = await anthropic.messages.create({
-                model: "claude-haiku-4-5-20251001",
-                max_tokens: 2048,
-                messages: [{
-                  role: "user",
-                  content: [
-                    {
-                      type: "image",
-                      source: {
-                        type: "base64",
-                        media_type: "image/png",
-                        data: pngBuffer.toString("base64"),
-                      },
-                    },
-                    {
-                      type: "text",
-                      text: "Extract all text from this document page. Return only the raw extracted text with no commentary.",
-                    },
-                  ],
-                }],
-              });
-              const first = aiResponse.content[0];
-              if (first.type === "text") {
-                aiText = first.text.trim();
-              }
+              aiText = await callAiVision(pngBuffer, aiConfig);
             } catch (aiErr) {
               aiErrMsg = (aiErr as Error).message;
               logger.warn("PDF text sample: AI vision failed", {
@@ -237,9 +270,9 @@ export async function runPdfTextSample(
             logger.info("PDF text sample: extracted via AI vision", {
               filename: asset.filename,
               chars: aiText.length,
+              model: aiConfig.pdf_extraction?.ai_vision_model_id,
             });
           } else {
-            // All methods exhausted — use best available text
             const finalText = ocrText.length > 0 ? ocrText : text;
             const finalCount = finalText.length;
             const method: "pdf_text" | "likely_scanned" | "failed" =

--- a/apps/windows-agent/package.json
+++ b/apps/windows-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {
@@ -14,7 +14,6 @@
     "dotenv": "^16.4.5",
     "@anthropic-ai/sdk": "^0.30.0",
     "mupdf": "^1.26.0",
-    "pdf-parse": "^1.1.1",
     "sharp": "^0.33.0",
     "tesseract.js": "^5.0.0"
   },

--- a/apps/windows-agent/src/api-client.ts
+++ b/apps/windows-agent/src/api-client.ts
@@ -61,6 +61,9 @@ export interface WindowsHeartbeatResponse {
     };
     ai?: {
       anthropic_api_key?: string;
+      google_ai_api_key?: string;
+      models?: Array<{ id: string; provider: string; apiModel: string; capabilities: string[] }>;
+      pdf_extraction?: { ai_vision_model_id?: string } | null;
     };
   };
   commands?: {

--- a/apps/windows-agent/src/index.ts
+++ b/apps/windows-agent/src/index.ts
@@ -27,7 +27,7 @@ import { shouldSkipPath, resetSkipWarnings } from "@popdam/path-filters";
 import { startJanitor } from "./janitor";
 import path from "node:path";
 import { writeFile } from "node:fs/promises";
-import { runPdfTextSample, type PdfSampleAsset } from "./pdf-text-sampler";
+import { runPdfTextSample, type PdfSampleAsset, type AiModelDef } from "./pdf-text-sampler";
 
 // ── State ───────────────────────────────────────────────────────
 
@@ -63,6 +63,9 @@ let cloudSpacesSecret = config.doSpacesSecret;
 let cloudNasUsername = "";
 let cloudNasPassword = "";
 let cloudAnthropicApiKey = "";
+let cloudGoogleAiApiKey = "";
+let cloudAiModels: AiModelDef[] = [];
+let cloudPdfExtractionConfig: { ai_vision_model_id: string } | null = null;
 
 // ── Pairing ─────────────────────────────────────────────────────
 
@@ -242,9 +245,15 @@ async function applyCloudConfig(response: api.WindowsHeartbeatResponse) {
     });
   }
 
-  // Update Anthropic API key
-  if (response.config?.ai?.anthropic_api_key) {
-    cloudAnthropicApiKey = response.config.ai.anthropic_api_key;
+  // Update AI config
+  if (response.config?.ai) {
+    const ai = response.config.ai;
+    if (ai.anthropic_api_key) cloudAnthropicApiKey = ai.anthropic_api_key;
+    if (ai.google_ai_api_key) cloudGoogleAiApiKey = ai.google_ai_api_key;
+    if (Array.isArray(ai.models) && ai.models.length > 0) cloudAiModels = ai.models as AiModelDef[];
+    if (ai.pdf_extraction !== undefined) {
+      cloudPdfExtractionConfig = (ai.pdf_extraction as { ai_vision_model_id: string } | null) ?? null;
+    }
   }
 }
 
@@ -269,7 +278,12 @@ function startHeartbeat() {
         const mountRoot = cloudNasMountPath.trim() || `\\\\${cloudNasHost}\\${cloudNasShare}`;
         isSamplingPdfText = true;
         logger.info("PDF text sample requested via heartbeat", { count: assets.length });
-        runPdfTextSample(assets, mountRoot, cloudAnthropicApiKey || undefined).finally(() => {
+        runPdfTextSample(assets, mountRoot, {
+          models: cloudAiModels,
+          pdf_extraction: cloudPdfExtractionConfig,
+          googleApiKey: cloudGoogleAiApiKey,
+          anthropicApiKey: cloudAnthropicApiKey,
+        }).finally(() => {
           isSamplingPdfText = false;
         });
       }

--- a/apps/windows-agent/src/pdf-text-sampler.ts
+++ b/apps/windows-agent/src/pdf-text-sampler.ts
@@ -3,9 +3,8 @@ import { join } from "node:path";
 import { logger } from "./logger";
 import * as api from "./api-client";
 
-// pdf-parse, mupdf, tesseract.js, and @anthropic-ai/sdk are only available after
-// a full installer run, not OTA dist updates. Load them lazily inside the function
-// so a missing module never crashes startup.
+// OTA-safe: mupdf, tesseract.js, and @anthropic-ai/sdk are only available after
+// a full installer run, not OTA dist updates. Load them lazily inside the function.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dynamicImport = new Function("m", "return import(m)") as (m: string) => Promise<any>;
 
@@ -25,6 +24,20 @@ export interface PdfSampleAsset {
   filename: string;
 }
 
+export interface AiModelDef {
+  id: string;
+  provider: string;
+  apiModel: string;
+  capabilities: string[];
+}
+
+export interface AiConfig {
+  models: AiModelDef[];
+  pdf_extraction: { ai_vision_model_id: string } | null;
+  googleApiKey: string;
+  anthropicApiKey: string;
+}
+
 export interface PdfTextSampleResult {
   asset_id: string;
   filename: string;
@@ -36,10 +49,87 @@ export interface PdfTextSampleResult {
   extraction_error: string | null;
 }
 
+// ── AI vision call (provider-agnostic, resolved from model catalog) ──────────
+
+async function callAiVision(pngBuffer: Buffer, aiConfig: AiConfig): Promise<string> {
+  const modelId = aiConfig.pdf_extraction?.ai_vision_model_id;
+  if (!modelId) return "";
+
+  const modelDef = aiConfig.models.find((m) => m.id === modelId);
+  if (!modelDef) {
+    logger.warn("PDF text sample: ai vision model not found in catalog", { modelId });
+    return "";
+  }
+  if (!modelDef.capabilities.includes("vision")) {
+    logger.warn("PDF text sample: selected model has no vision capability", { modelId });
+    return "";
+  }
+
+  const base64 = pngBuffer.toString("base64");
+
+  if (modelDef.provider === "google") {
+    if (!aiConfig.googleApiKey) {
+      logger.warn("PDF text sample: GOOGLE_AI_API_KEY not configured");
+      return "";
+    }
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelDef.apiModel}:generateContent?key=${aiConfig.googleApiKey}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(60_000),
+      body: JSON.stringify({
+        contents: [{
+          role: "user",
+          parts: [
+            { inlineData: { mimeType: "image/png", data: base64 } },
+            { text: "Extract all text from this document page. Return only the raw extracted text with no commentary." },
+          ],
+        }],
+      }),
+    });
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Gemini API ${res.status}: ${errText.slice(0, 200)}`);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = await res.json() as any;
+    return (data?.candidates?.[0]?.content?.parts?.[0]?.text as string || "").trim();
+
+  } else if (modelDef.provider === "anthropic") {
+    if (!aiConfig.anthropicApiKey) {
+      logger.warn("PDF text sample: ANTHROPIC_API_KEY not configured");
+      return "";
+    }
+    const AnthropicLib = tryRequire("@anthropic-ai/sdk");
+    if (!AnthropicLib) throw new Error("@anthropic-ai/sdk not installed");
+    const Anthropic = AnthropicLib.default ?? AnthropicLib;
+    const anthropic = new Anthropic({ apiKey: aiConfig.anthropicApiKey });
+    const aiResponse = await anthropic.messages.create({
+      model: modelDef.apiModel,
+      max_tokens: 2048,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "image", source: { type: "base64", media_type: "image/png", data: base64 } },
+          { type: "text", text: "Extract all text from this document page. Return only the raw extracted text with no commentary." },
+        ],
+      }],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const first = aiResponse.content[0] as any;
+    return (first?.type === "text" ? (first.text as string) : "").trim();
+  }
+
+  logger.warn("PDF text sample: unsupported ai vision provider", { provider: modelDef.provider });
+  return "";
+}
+
+// ── Main sampler ──────────────────────────────────────────────────────────────
+
 export async function runPdfTextSample(
   assets: PdfSampleAsset[],
   mountRoot: string,
-  anthropicApiKey?: string,
+  aiConfig: AiConfig,
 ): Promise<void> {
   if (assets.length === 0) {
     logger.info("PDF text sample: no assets to process");
@@ -64,48 +154,28 @@ export async function runPdfTextSample(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let mupdfDoc: any = null;
 
-      // ── Step 1: pdf-parse (primary text extraction) ──────────────────
+      // ── Step 1: mupdf text extraction (primary) ─────────────────────────────
       try {
-        const pdfParse = tryRequire("pdf-parse") as ((buf: Buffer) => Promise<{ text: string; numpages: number }>) | null;
-        if (!pdfParse) throw new Error("pdf-parse not installed");
-        const parsed = await Promise.race([
-          pdfParse(buffer),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("pdf-parse timed out after 30s")), 30_000)
-          ),
-        ]);
-        rawText = parsed.text || "";
-        numPages = parsed.numpages;
-      } catch (primaryErr) {
-        logger.warn("PDF text sample: pdf-parse failed, trying mupdf text extraction", {
-          filename: asset.filename,
-          error: (primaryErr as Error).message,
-        });
-
-        // ── Step 2: mupdf text extraction (fallback) ──────────────────
-        try {
-          mupdfRef = await dynamicImport("mupdf").catch(() => null);
-          if (!mupdfRef) throw new Error("mupdf not installed");
-          mupdfDoc = mupdfRef.Document.openDocument(buffer, "application/pdf");
-          numPages = mupdfDoc.countPages();
-          const parts: string[] = [];
-          for (let p = 0; p < numPages; p++) {
-            parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
-          }
-          rawText = parts.join("\n");
-        } catch (mupdfErr) {
-          logger.warn("PDF text sample: mupdf text extraction also failed", {
-            filename: asset.filename,
-            error: (mupdfErr as Error).message,
-          });
+        mupdfRef = await dynamicImport("mupdf").catch(() => null);
+        if (!mupdfRef) throw new Error("mupdf not installed");
+        mupdfDoc = mupdfRef.Document.openDocument(buffer, "application/pdf");
+        numPages = mupdfDoc.countPages();
+        const parts: string[] = [];
+        for (let p = 0; p < numPages; p++) {
+          parts.push(mupdfDoc.loadPage(p).toStructuredText("preserve-whitespace").asText());
         }
+        rawText = parts.join("\n");
+      } catch (mupdfErr) {
+        logger.warn("PDF text sample: mupdf text extraction failed", {
+          filename: asset.filename,
+          error: (mupdfErr as Error).message,
+        });
       }
 
       const text = rawText.trim();
       const charCount = text.length;
 
       if (charCount >= 100) {
-        // Sufficient native text — done
         result = {
           asset_id: asset.id,
           filename: asset.filename,
@@ -116,15 +186,15 @@ export async function runPdfTextSample(
           char_count: charCount,
           extraction_error: null,
         };
-        logger.info("PDF text sample: extracted via text", {
+        logger.info("PDF text sample: extracted via mupdf text", {
           filename: asset.filename,
           chars: charCount,
           pages: numPages,
         });
       } else {
-        // Sparse or no text — try OCR then AI vision
+        // Sparse or no text — render page 0 for OCR + AI vision
 
-        // ── Step 3: render page 0 to PNG via mupdf (used by OCR + AI) ──
+        // ── Step 2: render page 0 to PNG via mupdf ────────────────────────────
         let pngBuffer: Buffer | null = null;
         try {
           if (!mupdfRef) mupdfRef = await dynamicImport("mupdf").catch(() => null);
@@ -145,7 +215,7 @@ export async function runPdfTextSample(
           });
         }
 
-        // ── Step 4: OCR via tesseract.js ──────────────────────────────
+        // ── Step 3: OCR via tesseract.js ──────────────────────────────────────
         let ocrText = "";
         if (pngBuffer) {
           try {
@@ -180,41 +250,12 @@ export async function runPdfTextSample(
             chars: ocrText.length,
           });
         } else {
-          // ── Step 5: AI vision via Claude ──────────────────────────────
+          // ── Step 4: AI vision ─────────────────────────────────────────────
           let aiText = "";
           let aiErrMsg = "";
-          if (pngBuffer && anthropicApiKey) {
+          if (pngBuffer) {
             try {
-              const AnthropicLib = tryRequire("@anthropic-ai/sdk");
-              if (!AnthropicLib) throw new Error("@anthropic-ai/sdk not installed");
-              const Anthropic = AnthropicLib.default ?? AnthropicLib;
-              const anthropic = new Anthropic({ apiKey: anthropicApiKey });
-              const aiResponse = await anthropic.messages.create({
-                model: "claude-haiku-4-5-20251001",
-                max_tokens: 2048,
-                messages: [{
-                  role: "user",
-                  content: [
-                    {
-                      type: "image",
-                      source: {
-                        type: "base64",
-                        media_type: "image/png",
-                        data: pngBuffer.toString("base64"),
-                      },
-                    },
-                    {
-                      type: "text",
-                      text: "Extract all text from this document page. Return only the raw extracted text with no commentary.",
-                    },
-                  ],
-                }],
-              });
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const first = aiResponse.content[0] as any;
-              if (first && first.type === "text") {
-                aiText = (first.text as string).trim();
-              }
+              aiText = await callAiVision(pngBuffer, aiConfig);
             } catch (aiErr) {
               aiErrMsg = (aiErr as Error).message;
               logger.warn("PDF text sample: AI vision failed", {
@@ -238,9 +279,9 @@ export async function runPdfTextSample(
             logger.info("PDF text sample: extracted via AI vision", {
               filename: asset.filename,
               chars: aiText.length,
+              model: aiConfig.pdf_extraction?.ai_vision_model_id,
             });
           } else {
-            // All methods exhausted — use best available text
             const finalText = ocrText.length > 0 ? ocrText : text;
             const finalCount = finalText.length;
             const method: "pdf_text" | "likely_scanned" | "failed" =

--- a/src/components/settings/PdfTextSamplesTab.tsx
+++ b/src/components/settings/PdfTextSamplesTab.tsx
@@ -1,19 +1,31 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Loader2, FileText, CheckCircle2, XCircle, AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Loader2, FileText, CheckCircle2, XCircle, AlertTriangle, ChevronDown, ChevronUp, ScanLine, Sparkles, Save } from "lucide-react";
 import { toast } from "sonner";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface AiModelDef {
+  id: string;
+  provider: string;
+  apiModel: string;
+  displayName: string;
+  capabilities: string[];
+}
 
 interface PdfSample {
   id: string;
   asset_id: string | null;
   filename: string;
   relative_path: string;
-  extraction_method: "pdf_text" | "likely_scanned" | "failed";
+  extraction_method: "pdf_text" | "likely_scanned" | "failed" | "ocr_text" | "ai_vision";
   extracted_text: string | null;
   page_count: number | null;
   char_count: number;
@@ -21,11 +33,27 @@ interface PdfSample {
   sampled_at: string;
 }
 
+// ── Method badge ───────────────────────────────────────────────────────────────
+
 function MethodBadge({ method }: { method: PdfSample["extraction_method"] }) {
   if (method === "pdf_text") {
     return (
       <Badge className="bg-green-100 text-green-800 gap-1 text-xs">
         <CheckCircle2 className="h-3 w-3" /> Native text
+      </Badge>
+    );
+  }
+  if (method === "ocr_text") {
+    return (
+      <Badge className="bg-blue-100 text-blue-800 gap-1 text-xs">
+        <ScanLine className="h-3 w-3" /> OCR
+      </Badge>
+    );
+  }
+  if (method === "ai_vision") {
+    return (
+      <Badge className="bg-purple-100 text-purple-800 gap-1 text-xs">
+        <Sparkles className="h-3 w-3" /> AI vision
       </Badge>
     );
   }
@@ -42,6 +70,8 @@ function MethodBadge({ method }: { method: PdfSample["extraction_method"] }) {
     </Badge>
   );
 }
+
+// ── Sample row ────────────────────────────────────────────────────────────────
 
 function SampleRow({ sample }: { sample: PdfSample }) {
   const [expanded, setExpanded] = useState(false);
@@ -91,6 +121,107 @@ function SampleRow({ sample }: { sample: PdfSample }) {
   );
 }
 
+// ── AI vision model config card ───────────────────────────────────────────────
+
+function AiVisionConfigCard() {
+  const { call } = useAdminApi();
+  const queryClient = useQueryClient();
+
+  const { data: configData } = useQuery({
+    queryKey: ["admin-config", "AI_MODELS", "PDF_EXTRACTION_CONFIG"],
+    queryFn: () => call("get-config", { keys: ["AI_MODELS", "PDF_EXTRACTION_CONFIG"] }),
+  });
+
+  const allModels: AiModelDef[] = (() => {
+    const raw = configData?.config?.AI_MODELS?.value ?? configData?.config?.AI_MODELS;
+    return Array.isArray(raw) ? (raw as AiModelDef[]) : [];
+  })();
+
+  const visionModels = allModels.filter((m) => m.capabilities.includes("vision"));
+
+  const savedModelId: string = (() => {
+    const raw = configData?.config?.PDF_EXTRACTION_CONFIG?.value ?? configData?.config?.PDF_EXTRACTION_CONFIG;
+    return (raw as Record<string, string> | null)?.ai_vision_model_id ?? "";
+  })();
+
+  const [selectedModelId, setSelectedModelId] = useState("");
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (savedModelId && !loaded) {
+      setSelectedModelId(savedModelId);
+      setLoaded(true);
+    }
+  }, [savedModelId, loaded]);
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      call("set-config", { entries: { PDF_EXTRACTION_CONFIG: { ai_vision_model_id: selectedModelId } } }),
+    onSuccess: () => {
+      toast.success("AI vision model saved — takes effect on next PDF sample run");
+      queryClient.invalidateQueries({ queryKey: ["admin-config", "AI_MODELS", "PDF_EXTRACTION_CONFIG"] });
+      setLoaded(false);
+    },
+    onError: (e: Error) => toast.error(e.message || "Failed to save"),
+  });
+
+  const isDirty = selectedModelId !== savedModelId;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Sparkles className="h-4 w-4" />
+          AI Vision Model
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Used as the final fallback when mupdf text extraction and OCR both fail (e.g. scanned PDFs with no machine-readable text).
+          Only models with <code className="text-xs">vision</code> capability are shown.
+        </p>
+        {visionModels.length === 0 ? (
+          <p className="text-sm text-amber-600">
+            No vision models found. Add models to <code className="text-xs">AI_MODELS</code> in admin_config (same format as Openclaw <code className="text-xs">config/models.json</code>).
+          </p>
+        ) : (
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-1.5">
+              <Label className="text-xs">Vision model</Label>
+              <Select value={selectedModelId} onValueChange={setSelectedModelId}>
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue placeholder="Select a vision model…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {visionModels.map((m) => (
+                    <SelectItem key={m.id} value={m.id} className="text-xs">
+                      {m.displayName || m.id}
+                      <span className="ml-2 text-muted-foreground text-[10px]">({m.provider})</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              size="sm"
+              disabled={!isDirty || !selectedModelId || saveMutation.isPending}
+              onClick={() => saveMutation.mutate()}
+              className="h-8"
+            >
+              {saveMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <><Save className="h-3.5 w-3.5 mr-1.5" />Save</>}
+            </Button>
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          API keys: set <code>GOOGLE_AI_API_KEY</code> or <code>ANTHROPIC_API_KEY</code> in admin_config.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Main tab ──────────────────────────────────────────────────────────────────
+
 export default function PdfTextSamplesTab() {
   const { call } = useAdminApi();
   const queryClient = useQueryClient();
@@ -118,6 +249,8 @@ export default function PdfTextSamplesTab() {
   const isPending = request?.status === "pending";
 
   const nativeText = samples.filter((s) => s.extraction_method === "pdf_text").length;
+  const ocrText = samples.filter((s) => s.extraction_method === "ocr_text").length;
+  const aiVision = samples.filter((s) => s.extraction_method === "ai_vision").length;
   const likelyScanned = samples.filter((s) => s.extraction_method === "likely_scanned").length;
   const failed = samples.filter((s) => s.extraction_method === "failed").length;
 
@@ -145,24 +278,28 @@ export default function PdfTextSamplesTab() {
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            Picks 25 random tech pack / licensing sheet PDFs and attempts native text extraction.
-            Results show whether each PDF contains selectable text or appears to be a scanned image.
+            Picks 25 random tech pack / licensing sheet PDFs and attempts text extraction via mupdf → OCR → AI vision cascade.
+            Results show how each PDF is classified.
           </p>
           {request?.status === "pending" && (
             <div className="mt-3 flex items-center gap-2 text-sm text-amber-600">
               <Loader2 className="h-4 w-4 animate-spin" />
-              Waiting for bridge agent to process… (checks every 5s)
+              Processing… (checks every 5s)
             </div>
           )}
         </CardContent>
       </Card>
 
+      <AiVisionConfigCard />
+
       {samples.length > 0 && (
         <Card>
           <CardHeader className="pb-2">
-            <div className="flex items-center gap-3 text-sm">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
               <span className="font-medium">{samples.length} PDFs sampled</span>
-              <Badge className="bg-green-100 text-green-800">{nativeText} native text</Badge>
+              {nativeText > 0 && <Badge className="bg-green-100 text-green-800">{nativeText} native text</Badge>}
+              {ocrText > 0 && <Badge className="bg-blue-100 text-blue-800">{ocrText} OCR</Badge>}
+              {aiVision > 0 && <Badge className="bg-purple-100 text-purple-800">{aiVision} AI vision</Badge>}
               {likelyScanned > 0 && <Badge className="bg-amber-100 text-amber-800">{likelyScanned} likely scanned</Badge>}
               {failed > 0 && <Badge className="bg-red-100 text-red-800">{failed} failed</Badge>}
             </div>

--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -104,6 +104,9 @@ const HEARTBEAT_CONFIG_KEYS = [
   "STYLE_GUIDE_SCAN_ROOTS",
   "STYLE_GUIDE_CRAWL_REQUEST",
   "ANTHROPIC_API_KEY",
+  "GOOGLE_AI_API_KEY",
+  "AI_MODELS",
+  "PDF_EXTRACTION_CONFIG",
 ];
 
 async function handleHeartbeat(
@@ -429,6 +432,9 @@ async function handleHeartbeat(
       },
       ai: {
         anthropic_api_key: (configMap.ANTHROPIC_API_KEY as string) || "",
+        google_ai_api_key: (configMap.GOOGLE_AI_API_KEY as string) || "",
+        models: (configMap.AI_MODELS as unknown[]) || [],
+        pdf_extraction: (configMap.PDF_EXTRACTION_CONFIG as Record<string, unknown>) || null,
       },
     },
     commands: {


### PR DESCRIPTION
## Summary

- **Drop pdf-parse** — mupdf is the industry-standard C library (used in Chrome, Adobe Reader); pdf-parse is a JS reimplementation that hangs on malformed PDFs requiring a 30s timeout hack. Removed from both agents.
- **New 3-step cascade**: mupdf text extraction → OCR (tesseract.js) → AI vision
- **Provider-agnostic AI vision**: model resolved from `AI_MODELS` admin_config catalog (same format as Openclaw `config/models.json`). `PDF_EXTRACTION_CONFIG` stores `{ ai_vision_model_id: "..." }` — zero hard-coded model names in code
- **Google/Anthropic dispatch**: `provider: "google"` → Gemini REST `fetch()` (same pattern as worker ai-tagging); `provider: "anthropic"` → `@anthropic-ai/sdk`
- **New admin_config keys**: `AI_MODELS` (model catalog), `GOOGLE_AI_API_KEY`, `PDF_EXTRACTION_CONFIG`
- **PdfTextSamplesTab UI**: new blue OCR badge, purple AI vision badge, vision model picker (filters to capability `"vision"`, shows displayName from catalog)
- **windows-agent v0.8.1**, **bridge-agent v1.6.1**

## Setup
1. Add `AI_MODELS` to admin_config — seed with Openclaw `config/models.json` contents
2. Add `GOOGLE_AI_API_KEY` (and/or `ANTHROPIC_API_KEY`) to admin_config
3. In settings → PDF Text Samples → select AI Vision Model (e.g. `gemini-3.1-flash-image-preview`)

https://claude.ai/code/session_01WKjhiKYJ2TETeSxGNBDDpt