### PR TITLE
fix: clear stale update error on successful check (windows-agent v0.8.2)

### DIFF
--- a/apps/windows-agent/package.json
+++ b/apps/windows-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popdam/windows-agent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/apps/windows-agent/src/updater.ts
+++ b/apps/windows-agent/src/updater.ts
@@ -198,6 +198,8 @@ async function checkForUpdate(agentId: string, forceApply = false): Promise<void
     logger.info("Checking for updates...");
     const info = await api.getLatestBuild();
 
+    // Clear any previous error — we successfully contacted the server
+    state.lastError = null;
     state.lastCheckAt = new Date().toISOString();
     state.latestVersion = info.latest_version;
 


### PR DESCRIPTION
## Summary

`state.lastError` in `updater.ts` was only cleared inside `applyUpdate()`. If `get-latest-build` succeeded but found the agent was already on the latest version, the old error (e.g. the 401 from before the server fix) stayed in `state` forever — the UI kept showing "Update error: agent-api get-latest-build returned 401..." even though the server-side issue was fixed.

Fix: clear `state.lastError` immediately after any successful `get-latest-build` response, before version comparison.

Bumps to v0.8.2 so CI builds a new release the agent will update to.

https://claude.ai/code/session_01WKjhiKYJ2TETeSxGNBDDpt