### PR TITLE
Fix erp-sync dropping batches on duplicate external_ids from API

### DIFF
--- a/supabase/functions/erp-sync/index.ts
+++ b/supabase/functions/erp-sync/index.ts
@@ -275,14 +275,24 @@ serve(async (req: Request) => {
           };
         });
 
+        // Deduplicate by external_id — API sometimes returns the same item twice,
+        // which causes Postgres to reject the entire batch with "ON CONFLICT DO UPDATE
+        // command cannot affect row a second time".
+        const seen = new Set<string>();
+        const dedupedRows = normalizedRows.filter((r) => {
+          if (seen.has(r.external_id)) return false;
+          seen.add(r.external_id);
+          return true;
+        });
+
         const { error: upsertErr } = await db.from("erp_items_current")
-          .upsert(normalizedRows, { onConflict: "external_id" });
+          .upsert(dedupedRows, { onConflict: "external_id" });
 
         if (upsertErr) {
-          totalErrors += batch.length;
+          totalErrors += dedupedRows.length;
           if (errorSamples.length < 5) errorSamples.push(upsertErr.message);
         } else {
-          totalUpserted += batch.length;
+          totalUpserted += dedupedRows.length;
         }
       } catch (e) {
         totalErrors += batch.length;


### PR DESCRIPTION
The ERP API sometimes returns the same item twice in a response. When two rows with the same `external_id` land in the same 100-item batch, Postgres rejects the entire batch with "ON CONFLICT DO UPDATE command cannot affect row a second time", silently dropping all 100 items.

Fix: deduplicate `normalizedRows` by `external_id` before upserting. The last occurrence wins (consistent with upsert semantics).

The last full sync showed 200 errors / ~2 failed batches, meaning ~200 items were missed including `HGP62WWSU01`. Run a Full Sync after this deploys to recover them.