### PR TITLE
Fix full sync sending endDate to API, causing partial results (16,939 of 18,591)

### DIFF
--- a/supabase/functions/erp-sync/index.ts
+++ b/supabase/functions/erp-sync/index.ts
@@ -7,8 +7,6 @@ const DEFAULT_ERP_ENDPOINT = "https://api.designflow.app/api/item_master/lib/get
 const BATCH_SIZE = 100;
 const WATERMARK_KEY = "ERP_LAST_SYNC_DATE";
 const DEFAULT_CATEGORY_CUTOFF = "2025-05-10";
-/** Hard floor: reject any item created before this date */
-const INGESTION_MIN_DATE = "2020-01-01";
 
 /** Format a Date as YYYY-MM-DD */
 function fmtDate(d: Date): string {
@@ -74,12 +72,12 @@ serve(async (req: Request) => {
       }
     }
 
-    // Default endDate = today
-    if (!endDate) {
+    // For incremental syncs, default endDate = today. For full syncs, send no
+    // date params so the API returns its complete dataset without date filtering.
+    const syncMode = startDate ? "incremental" : "full";
+    if (syncMode === "incremental" && !endDate) {
       endDate = fmtDate(new Date());
     }
-
-    const syncMode = startDate ? "incremental" : "full";
     console.log(`erp-sync: mode=${syncMode}, startDate=${startDate ?? "none"}, endDate=${endDate}`);
 
     // ── Run lock ──────────────────────────────────────────────────────
@@ -179,19 +177,6 @@ serve(async (req: Request) => {
     }
 
     console.log(`erp-sync: fetched ${items.length} items`);
-
-    // ── Filter out items before ingestion floor ────────────────────────
-    const originalCount = items.length;
-    items = items.filter((item: any) => {
-      const createdDate = item.created_date || item.createdDate || null;
-      if (!createdDate) return true; // No date = keep (can't determine age)
-      const dateStr = String(createdDate).slice(0, 10);
-      return dateStr >= INGESTION_MIN_DATE;
-    });
-    const rejectedCount = originalCount - items.length;
-    if (rejectedCount > 0) {
-      console.log(`erp-sync: rejected ${rejectedCount} items created before ${INGESTION_MIN_DATE} (${items.length} remaining)`);
-    }
 
     let totalUpserted = 0;
     let totalErrors = 0;


### PR DESCRIPTION
Full syncs were sending `endDate=today` to the API, which filtered results to items with dates on or before today — returning only ~16,939 of 18,591 items and missing items like `HGP62WWSU01`.\n\nFix: full syncs now send no date params at all, so the API returns its complete dataset. Incremental syncs still send `startDate` + `endDate` as before.\n\nAlso removes the `INGESTION_MIN_DATE` floor filter so all items are ingested regardless of age.