### PR TITLE
Derive mg_category from MG01 code in ERP Items Browser

### DIFF
--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { getMg01Desc, getMg02Desc, getMg03Desc } from "@/lib/mg-lookup";
+import { getMgCategory, getMg01Desc, getMg02Desc, getMg03Desc } from "@/lib/mg-lookup";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { usePersistentOperation } from "@/hooks/usePersistentOperation";
@@ -1541,7 +1541,17 @@ function ErpItemsBrowser() {
                               className="p-2 align-middle text-xs overflow-hidden text-ellipsis whitespace-nowrap"
                               style={colWidths[col.key] ? { width: colWidths[col.key], maxWidth: colWidths[col.key] } : undefined}
                             >
-                              {col.key === "mg01_code" ? (
+                              {col.key === "mg_category" ? (
+                                (() => {
+                                  const cat = item.mg_category || getMgCategory(item.mg01_code);
+                                  const derived = !item.mg_category && !!cat;
+                                  return cat ? (
+                                    <span className={derived ? "text-foreground/60 italic" : "text-foreground"}>{cat}</span>
+                                  ) : (
+                                    <span className="text-muted-foreground/40">—</span>
+                                  );
+                                })()
+                              ) : col.key === "mg01_code" ? (
                                 renderMgCell(item.mg01_code, getMg01Desc(item.mg01_code))
                               ) : col.key === "mg02_code" ? (
                                 renderMgCell(item.mg02_code, getMg02Desc(item.mg01_code, item.mg02_code))

--- a/src/lib/mg-lookup.ts
+++ b/src/lib/mg-lookup.ts
@@ -7,6 +7,29 @@
  * MG03 description: keyed by "mg01:mg02:mg03"
  */
 
+/** mgCategory derived from MG01 code (CSV column 1 ↔ column 2 mapping) */
+const MG01_CATEGORY: Record<string, string> = {
+  A: "Wall",
+  B: "Wall",
+  C: "Wall",
+  D: "Wall",
+  E: "Wall",
+  F: "Tabletop",
+  G: "Tabletop",
+  H: "Tabletop",
+  J: "Tabletop",
+  K: "Tabletop",
+  M: "Clock",
+  N: "Storage",
+  P: "Storage",
+  R: "Storage",
+  S: "Workspace",
+  T: "Workspace",
+  U: "Workspace",
+  V: "Floor",
+  W: "Garden",
+};
+
 const MG01_DESC: Record<string, string> = {
   A: "Stretched/Box",
   B: "Framed",
@@ -341,6 +364,12 @@ const MG03_DESC: Record<string, string> = {
   "W:A:G": "Glove",
   "W:A:8": "Accessory Set",
 };
+
+/** Returns the mgCategory for a given MG01 code, or null if not found. */
+export function getMgCategory(mg01: string | null | undefined): string | null {
+  if (!mg01) return null;
+  return MG01_CATEGORY[mg01] ?? null;
+}
 
 export function getMg01Desc(mg01: string | null | undefined): string | null {
   if (!mg01) return null;


### PR DESCRIPTION
When an item has no `mg_category` from the ERP API, the Category column now derives it from the MG01 code using the CSV mapping:

- A/B/C/D/E → Wall
- F/G/H/J/K → Tabletop
- M → Clock
- N/P/R → Storage
- S/T/U → Workspace
- V → Floor
- W → Garden

Derived values display in italic to distinguish them from API-sourced values. Items with no MG01 code still show —. No DB changes required — this is a pure frontend lookup.