### PR TITLE
Add Created Date column and date range filter to ERP Items Browser

### DIFF
--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -1231,6 +1231,8 @@ function ErpItemsBrowser() {
   const [maxDigitsStyle, setMaxDigitsStyle] = useState<number | null>(null);
   const [maxDigitsDesc, setMaxDigitsDesc] = useState<number | null>(null);
   const [showDismissed, setShowDismissed] = useState(false);
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [lastClickedIdx, setLastClickedIdx] = useState<number | null>(null);
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
@@ -1244,7 +1246,7 @@ function ErpItemsBrowser() {
   };
 
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ["erp-items-browse", debouncedSearch, page, pageSize, sortBy, sortAsc, maxDigitsStyle, maxDigitsDesc, showDismissed],
+    queryKey: ["erp-items-browse", debouncedSearch, page, pageSize, sortBy, sortAsc, maxDigitsStyle, maxDigitsDesc, showDismissed, dateFrom, dateTo],
     queryFn: () => call("erp-items-browse", {
       search: debouncedSearch,
       page,
@@ -1254,6 +1256,8 @@ function ErpItemsBrowser() {
       show_dismissed: showDismissed,
       ...(maxDigitsStyle !== null ? { max_digits_style: maxDigitsStyle } : {}),
       ...(maxDigitsDesc !== null ? { max_digits_desc: maxDigitsDesc } : {}),
+      ...(dateFrom ? { date_from: dateFrom } : {}),
+      ...(dateTo ? { date_to: dateTo } : {}),
     }),
   });
 
@@ -1344,6 +1348,7 @@ function ErpItemsBrowser() {
     { key: "mg01_code", label: "MG01" },
     { key: "mg02_code", label: "MG02" },
     { key: "mg03_code", label: "MG03" },
+    { key: "erp_updated_at", label: "Created Date" },
     { key: "size_code", label: "Size" },
     { key: "licensor_code", label: "Licensor" },
     { key: "property_code", label: "Property" },
@@ -1437,8 +1442,26 @@ function ErpItemsBrowser() {
                 className="h-9 w-[70px] text-xs"
               />
             </div>
-            {(maxDigitsStyle !== null || maxDigitsDesc !== null) && (
-              <Button variant="ghost" size="sm" className="h-7 text-xs px-1.5" onClick={() => { setMaxDigitsStyle(null); setMaxDigitsDesc(null); setPage(1); }}>
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground whitespace-nowrap">Created from:</label>
+              <Input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => { setDateFrom(e.target.value); setPage(1); }}
+                className="h-9 w-[130px] text-xs"
+              />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground whitespace-nowrap">to:</label>
+              <Input
+                type="date"
+                value={dateTo}
+                onChange={(e) => { setDateTo(e.target.value); setPage(1); }}
+                className="h-9 w-[130px] text-xs"
+              />
+            </div>
+            {(maxDigitsStyle !== null || maxDigitsDesc !== null || dateFrom || dateTo) && (
+              <Button variant="ghost" size="sm" className="h-7 text-xs px-1.5" onClick={() => { setMaxDigitsStyle(null); setMaxDigitsDesc(null); setDateFrom(""); setDateTo(""); setPage(1); }}>
                 Clear filters
               </Button>
             )}
@@ -1545,11 +1568,9 @@ function ErpItemsBrowser() {
                                 (() => {
                                   const cat = item.mg_category || getMgCategory(item.mg01_code);
                                   const derived = !item.mg_category && !!cat;
-                                  return cat ? (
-                                    <span className={derived ? "text-foreground/60 italic" : "text-foreground"}>{cat}</span>
-                                  ) : (
-                                    <span className="text-muted-foreground/40">—</span>
-                                  );
+                                  return cat
+                                    ? <span className={derived ? "text-foreground/60 italic" : "text-foreground"}>{cat}</span>
+                                    : <span className="text-muted-foreground/40">—</span>;
                                 })()
                               ) : col.key === "mg01_code" ? (
                                 renderMgCell(item.mg01_code, getMg01Desc(item.mg01_code))
@@ -1557,6 +1578,10 @@ function ErpItemsBrowser() {
                                 renderMgCell(item.mg02_code, getMg02Desc(item.mg01_code, item.mg02_code))
                               ) : col.key === "mg03_code" ? (
                                 renderMgCell(item.mg03_code, getMg03Desc(item.mg01_code, item.mg02_code, item.mg03_code))
+                              ) : col.key === "erp_updated_at" ? (
+                                item.erp_updated_at
+                                  ? <span className="text-foreground">{new Date(item.erp_updated_at).toLocaleDateString()}</span>
+                                  : <span className="text-muted-foreground/40">—</span>
                               ) : col.key === "item_description" && item[col.key] ? (
                                 <TooltipProvider delayDuration={200}>
                                   <Tooltip>

--- a/src/lib/mg-lookup.ts
+++ b/src/lib/mg-lookup.ts
@@ -9,26 +9,20 @@
 
 /** mgCategory derived from MG01 code (CSV column 1 ↔ column 2 mapping) */
 const MG01_CATEGORY: Record<string, string> = {
-  A: "Wall",
-  B: "Wall",
-  C: "Wall",
-  D: "Wall",
-  E: "Wall",
-  F: "Tabletop",
-  G: "Tabletop",
-  H: "Tabletop",
-  J: "Tabletop",
-  K: "Tabletop",
+  A: "Wall", B: "Wall", C: "Wall", D: "Wall", E: "Wall",
+  F: "Tabletop", G: "Tabletop", H: "Tabletop", J: "Tabletop", K: "Tabletop",
   M: "Clock",
-  N: "Storage",
-  P: "Storage",
-  R: "Storage",
-  S: "Workspace",
-  T: "Workspace",
-  U: "Workspace",
+  N: "Storage", P: "Storage", R: "Storage",
+  S: "Workspace", T: "Workspace", U: "Workspace",
   V: "Floor",
   W: "Garden",
 };
+
+/** Returns the mgCategory for a given MG01 code, or null if not found. */
+export function getMgCategory(mg01: string | null | undefined): string | null {
+  if (!mg01) return null;
+  return MG01_CATEGORY[mg01] ?? null;
+}
 
 const MG01_DESC: Record<string, string> = {
   A: "Stretched/Box",
@@ -364,12 +358,6 @@ const MG03_DESC: Record<string, string> = {
   "W:A:G": "Glove",
   "W:A:8": "Accessory Set",
 };
-
-/** Returns the mgCategory for a given MG01 code, or null if not found. */
-export function getMgCategory(mg01: string | null | undefined): string | null {
-  if (!mg01) return null;
-  return MG01_CATEGORY[mg01] ?? null;
-}
 
 export function getMg01Desc(mg01: string | null | undefined): string | null {
   if (!mg01) return null;

--- a/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
@@ -290,6 +290,8 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
   const maxDigitsStyle = typeof body.max_digits_style === "number" ? body.max_digits_style : null;
   const maxDigitsDesc = typeof body.max_digits_desc === "number" ? body.max_digits_desc : null;
   const showDismissed = body.show_dismissed === true;
+  const dateFrom = typeof body.date_from === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.date_from) ? body.date_from : null;
+  const dateTo = typeof body.date_to === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.date_to) ? body.date_to : null;
   const offset = (page - 1) * pageSize;
 
   const ALLOWED_SORT_COLS = [
@@ -309,7 +311,7 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
   ];
   const effectiveSort = ALLOWED_SORT_COLS.includes(sortBy) ? sortBy : "synced_at";
 
-  const useRawSql = maxDigitsStyle !== null || maxDigitsDesc !== null;
+  const useRawSql = maxDigitsStyle !== null || maxDigitsDesc !== null || dateFrom !== null || dateTo !== null;
 
   if (useRawSql) {
     const conditions: string[] = [];
@@ -323,6 +325,9 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
       digitFilters.push(`(item_description IS NOT NULL AND length(item_description) <= ${maxDigitsDesc})`);
     }
     if (digitFilters.length > 0) conditions.push(`(${digitFilters.join(" OR ")})`);
+
+    if (dateFrom) conditions.push(`erp_updated_at >= '${dateFrom}'`);
+    if (dateTo) conditions.push(`erp_updated_at < '${dateTo}'::date + interval '1 day'`);
 
     if (search) {
       const esc = search.replace(/'/g, "''");
@@ -354,9 +359,9 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
   // Standard Supabase query path
   let countQuery = db.from("erp_items_current").select("id", { count: "exact", head: true });
   if (!showDismissed) countQuery = countQuery.eq("dismissed", false);
-  if (search) {
-    countQuery = countQuery.or(`style_number.ilike.%${search}%,item_description.ilike.%${search}%`);
-  }
+  if (search) countQuery = countQuery.or(`style_number.ilike.%${search}%,item_description.ilike.%${search}%`);
+  if (dateFrom) countQuery = countQuery.gte("erp_updated_at", dateFrom);
+  if (dateTo) countQuery = countQuery.lte("erp_updated_at", dateTo + "T23:59:59Z");
   const { count, error: countErr } = await countQuery;
   if (countErr) return err(countErr.message, 500);
 
@@ -367,9 +372,9 @@ export async function handleErpItemsBrowse(body: Record<string, unknown>) {
     .order(effectiveSort, { ascending: sortAsc, nullsFirst: false })
     .range(offset, offset + pageSize - 1);
   if (!showDismissed) dataQuery = dataQuery.eq("dismissed", false);
-  if (search) {
-    dataQuery = dataQuery.or(`style_number.ilike.%${search}%,item_description.ilike.%${search}%`);
-  }
+  if (search) dataQuery = dataQuery.or(`style_number.ilike.%${search}%,item_description.ilike.%${search}%`);
+  if (dateFrom) dataQuery = dataQuery.gte("erp_updated_at", dateFrom);
+  if (dateTo) dataQuery = dataQuery.lte("erp_updated_at", dateTo + "T23:59:59Z");
   const { data, error: dataErr } = await dataQuery;
   if (dataErr) return err(dataErr.message, 500);
 


### PR DESCRIPTION
- New **Created Date** column in the ERP Items Browser table (sortable by clicking the header, shows `erp_updated_at` formatted as a date)
- New **from / to date pickers** in the filter bar — narrows results to items whose Created Date falls within the range
- Backend (`erp-browse-handlers`) accepts `date_from` / `date_to` and applies the filter in both the raw SQL and standard Supabase query paths
- "Clear filters" button now also resets the date range