### PR TITLE
Store MG letter codes functionally, display API descriptions in browser

### DIFF
--- a/src/components/settings/ErpEnrichmentTab.tsx
+++ b/src/components/settings/ErpEnrichmentTab.tsx
@@ -250,19 +250,17 @@ function QualityDashboard() {
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <StatCard label="ERP Items Synced" value={s.total_erp_items ?? 0} icon={<Database className="h-4 w-4" />} tooltip="Total number of product records pulled from the ERP system" />
               <StatCard label="Has mgCategory" value={s.with_mg_category ?? 0} icon={<CheckCircle2 className="h-4 w-4 text-[hsl(var(--success))]" />} tooltip="ERP items where the ERP system itself provides a product category (mg_category field) — no AI needed" />
-              <StatCard label="No mgCategory" value={s.legacy_items ?? 0} icon={<Clock className="h-4 w-4 text-[hsl(var(--warning))]" />} tooltip="ERP items where the API did not provide an mgCategory value" />
+              <StatCard label="No mgCategory" value={(s.total_erp_items ?? 0) - (s.with_mg_category ?? 0)} icon={<Clock className="h-4 w-4 text-[hsl(var(--warning))]" />} tooltip="ERP items where the API did not provide an mgCategory value" />
               <StatCard label="Rule-Classified" value={s.rule_classified ?? 0} icon={<Zap className="h-4 w-4 text-primary" />} tooltip="Items whose product category was determined by deterministic code rules (e.g. 'Clock' items always map to the Clock category) — no AI call needed" />
               <StatCard label="AI-Classified" value={s.ai_classified ?? 0} icon={<Bot className="h-4 w-4 text-[hsl(var(--info))]" />} tooltip="Items where Claude AI looked at the description and MG codes and predicted a product category" />
               <StatCard label="Needs AI" value={s.needs_ai ?? 0} icon={<AlertCircle className="h-4 w-4 text-[hsl(var(--warning))]" />} tooltip="Items with no category yet that have a matching SKU in your asset library — eligible for AI classification. Run 'Classify Now' to process these." />
               <StatCard label="Pending Review" value={s.pending_review ?? 0} icon={<Clock className="h-4 w-4 text-[hsl(var(--warning))]" />} tooltip="AI predictions with confidence below 65% — Claude wasn't sure enough to auto-apply. These appear in the Review Queue for you to approve or reject." />
               <StatCard label="SKU Matched" value={s.sku_matched ?? 0} icon={<CheckCircle2 className="h-4 w-4" />} tooltip="ERP items whose style_number (SKU) exists in at least one asset or style group — these can actually be enriched" />
               <StatCard label="Unmatched SKUs" value={s.unmatched_skus ?? 0} icon={<AlertCircle className="h-4 w-4 text-destructive" />} tooltip="ERP items whose SKU doesn't match any asset or style group — enrichment has no effect on these until the assets are uploaded" />
+              {(s.unresolved_mg_codes ?? 0) > 0 && (
+                <StatCard label="Unresolved MG Codes" value={s.unresolved_mg_codes ?? 0} icon={<AlertCircle className="h-4 w-4 text-amber-500" />} tooltip="Items whose MG01 value from the ERP API couldn't be matched to a schema code — run a Full Sync to re-process after the ERP data is corrected" />
+              )}
             </div>
-            {s.category_cutoff && (
-              <p className="text-xs text-muted-foreground mt-2">
-                Category cutoff date: <strong className="text-foreground">{s.category_cutoff}</strong> — items before this date have mgCategory nulled and require AI classification.
-              </p>
-            )}
           </>
         )}
       </CardContent>
@@ -1542,8 +1540,36 @@ function ErpItemsBrowser() {
                           />
                         </td>
                         {ATTRIBUTE_COLS.map((col) => {
-                          const renderMgCell = (code: string | null, desc: string | null) => {
-                            if (!code) return <span className="text-muted-foreground/40">—</span>;
+                          /**
+                           * Render an MG cell. Shows the human-readable description with a
+                           * tooltip for the code. Handles three data states:
+                           *
+                           * 1. Normal (code + desc resolved): shows desc, tooltip "Code: X"
+                           * 2. Unresolved (no code, but raw API value exists): shows raw value
+                           *    in amber — description not in MG schema, needs ERP correction
+                           * 3. Pre-fix DB rows (description stored in code field): detected by
+                           *    code.length > 1; treated same as unresolved until re-synced
+                           * 4. Empty: shows "—"
+                           */
+                          const renderMgCell = (code: string | null, desc: string | null, rawApiValue?: string | null) => {
+                            // Detect pre-fix rows where description was stored in the code field
+                            const effectiveCode = code && code.length === 1 ? code : null;
+                            const effectiveRaw = rawApiValue || (code && code.length > 1 ? code : null);
+
+                            if (!effectiveCode && !effectiveRaw) return <span className="text-muted-foreground/40">—</span>;
+                            if (!effectiveCode && effectiveRaw) {
+                              // Description from API couldn't be matched to a schema code
+                              return (
+                                <TooltipProvider delayDuration={200}>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span className="cursor-help text-amber-600 dark:text-amber-400">{effectiveRaw}</span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top" className="text-xs">Not matched to MG schema — ERP data may need correction</TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              );
+                            }
                             if (!desc) return <span className="text-destructive font-medium">error</span>;
                             return (
                               <TooltipProvider delayDuration={200}>
@@ -1552,7 +1578,7 @@ function ErpItemsBrowser() {
                                     <span className="cursor-help">{desc}</span>
                                   </TooltipTrigger>
                                   <TooltipContent side="top" className="text-xs">
-                                    Code: {code}
+                                    Code: {effectiveCode}
                                   </TooltipContent>
                                 </Tooltip>
                               </TooltipProvider>
@@ -1566,18 +1592,21 @@ function ErpItemsBrowser() {
                             >
                               {col.key === "mg_category" ? (
                                 (() => {
-                                  const cat = item.mg_category || getMgCategory(item.mg01_code);
+                                  // mg_category: prefer API value; fall back to lookup from code
+                                  // getMgCategory only works with single-letter codes — safe post-fix
+                                  const effectiveMg01Code = item.mg01_code?.length === 1 ? item.mg01_code : null;
+                                  const cat = item.mg_category || getMgCategory(effectiveMg01Code);
                                   const derived = !item.mg_category && !!cat;
                                   return cat
                                     ? <span className={derived ? "text-foreground/60 italic" : "text-foreground"}>{cat}</span>
                                     : <span className="text-muted-foreground/40">—</span>;
                                 })()
                               ) : col.key === "mg01_code" ? (
-                                renderMgCell(item.mg01_code, getMg01Desc(item.mg01_code))
+                                renderMgCell(item.mg01_code, getMg01Desc(item.mg01_code), item.raw_mg_fields?.mg01)
                               ) : col.key === "mg02_code" ? (
-                                renderMgCell(item.mg02_code, getMg02Desc(item.mg01_code, item.mg02_code))
+                                renderMgCell(item.mg02_code, getMg02Desc(item.mg01_code, item.mg02_code), item.raw_mg_fields?.mg02)
                               ) : col.key === "mg03_code" ? (
-                                renderMgCell(item.mg03_code, getMg03Desc(item.mg01_code, item.mg02_code, item.mg03_code))
+                                renderMgCell(item.mg03_code, getMg03Desc(item.mg01_code, item.mg02_code, item.mg03_code), item.raw_mg_fields?.mg03)
                               ) : col.key === "erp_updated_at" ? (
                                 item.erp_updated_at
                                   ? <span className="text-foreground">{new Date(item.erp_updated_at).toLocaleDateString()}</span>

--- a/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
+++ b/supabase/functions/_shared/admin-handlers/erp-browse-handlers.ts
@@ -4,7 +4,6 @@
 
 import { err, json } from "../http.ts";
 import { serviceClient } from "../service-client.ts";
-import { unwrapConfigString } from "../config-utils.ts";
 import { optionalString, requireString } from "../validators.ts";
 
 // ── trigger-erp-sync ────────────────────────────────────────────────
@@ -106,23 +105,16 @@ export async function handleErpEnrichmentStats() {
 
   const needsAi = Math.max(0, (needsAiRaw ?? 0) - (alreadyHandled ?? 0));
 
-  let categoryCutoff = "2025-05-10";
-  try {
-    const { data: cutoffRow } = await db.from("admin_config")
-      .select("value").eq("key", "ERP_CATEGORY_CUTOFF_DATE").maybeSingle();
-    if (cutoffRow?.value) {
-      const raw = unwrapConfigString(cutoffRow.value);
-      if (raw && /^\d{4}-\d{2}-\d{2}/.test(raw)) categoryCutoff = raw.slice(0, 10);
-    }
-  } catch { /* use default */ }
-
-  const { count: legacyItems } = await db.from("erp_items_current")
-    .select("*", { count: "exact", head: true })
-    .lt("erp_updated_at", categoryCutoff + "T00:00:00Z");
-
   const { count: skuMatched } = await db.from("erp_items_current")
     .select("*", { count: "exact", head: true })
     .not("style_number", "is", null);
+
+  // Items where mg01_code couldn't be resolved to a schema code (single-char)
+  // These stored descriptions in the code field (pre-fix) or have unmatched API values
+  const { count: unresolvedMg } = await db.from("erp_items_current")
+    .select("*", { count: "exact", head: true })
+    .not("mg01_code", "is", null)
+    .not("mg01_code", "like", "_"); // single-char codes are length 1; descriptions are longer
 
   return json({
     ok: true,
@@ -134,8 +126,7 @@ export async function handleErpEnrichmentStats() {
     pending_review: pendingReview ?? 0,
     sku_matched: skuMatched ?? 0,
     unmatched_skus: (totalErp ?? 0) - (skuMatched ?? 0),
-    legacy_items: legacyItems ?? 0,
-    category_cutoff: categoryCutoff,
+    unresolved_mg_codes: unresolvedMg ?? 0,
   });
 }
 

--- a/supabase/functions/_shared/mg-codes.ts
+++ b/supabase/functions/_shared/mg-codes.ts
@@ -1,0 +1,231 @@
+/**
+ * MerchGroup code resolution helpers for the ERP sync pipeline.
+ *
+ * The ERP API returns either:
+ *   - Single-character letter/digit codes (e.g. "A", "3", "0") — legacy / already-correct format
+ *   - Full text descriptions (e.g. "Stretched/Box", "Canvas", "Foil") — post-May-2025 API format
+ *
+ * These functions detect which format is present and normalise to single-character codes,
+ * so that mg01_code / mg02_code / mg03_code in erp_items_current always hold the canonical
+ * letter/digit code. The original API value is preserved in raw_mg_fields for display.
+ */
+
+/** True if val is already a single-character code (letter or digit). */
+export function isMgCode(val: string | null | undefined): boolean {
+  if (!val) return false;
+  return val.trim().length === 1;
+}
+
+// ── MG01 ────────────────────────────────────────────────────────────────────
+
+/** Reverse map: MG01 description (lowercase) → single-letter code */
+const MG01_DESC_TO_CODE: Record<string, string> = {
+  "stretched/box": "A",
+  "framed": "B",
+  "plaque": "C",
+  "functional": "D",
+  "other wall": "E",
+  "block": "F",
+  "box": "G",
+  "photo frames": "H",
+  "object": "J",
+  "other tabletop": "K",
+  "clocks": "M",
+  "soft storage": "N",
+  "hard storage": "P",
+  "other storage": "R",
+  "stationery org": "S",
+  "desk acc": "T",
+  "other workspace": "U",
+  "floor coverings": "V",
+  "garden": "W",
+};
+
+/**
+ * Resolve an MG01 value from the API to a single-character code.
+ * Returns the code if val is already a code, reverse-looks up if it's a description,
+ * or returns null if it can't be resolved.
+ */
+export function resolveMg01Code(val: string | null | undefined): string | null {
+  if (!val) return null;
+  const trimmed = val.trim();
+  if (trimmed.length === 1) return trimmed; // already a code
+  return MG01_DESC_TO_CODE[trimmed.toLowerCase()] ?? null;
+}
+
+// ── MG02 ────────────────────────────────────────────────────────────────────
+
+/** Reverse map: mg01_code → { mg02_description_lowercase → mg02_code } */
+const MG02_DESC_TO_CODE: Record<string, Record<string, string>> = {
+  A: { "canvas": "A", "special material": "S", "greyboard": "G", "fabric": "F", "mdf box": "M" },
+  B: { "fabric": "F", "lenticular/3d": "3", "glass": "G", "object": "J", "mirror": "M", "print": "R" },
+  C: { "plain": "A", "diy": "D", "leaner": "P", "relief/3d molded": "R", "sign": "S", "plastic": "T", "lenticular": "3", "other": "9" },
+  D: { "countdown calendar": "C", "hook": "H", "framed": "F", "shelf": "S", "memo board": "M" },
+  E: { "dimensional": "D", "hanging": "H", "string": "S", "box": "B", "shades": "6" },
+  F: { "none": "0", "glass": "G", "monogram": "M", "led": "E", "word": "W", "calendar": "C" },
+  G: { "ceramic": "C", "glass": "G", "mdf": "M" },
+  H: { "single": "S", "collage": "C", "infant": "F" },
+  J: { "book end": "B", "candle": "C", "planter": "P", "orb": "R", "lightup led": "D", "easel": "E", "snow globe": "G", "figural": "U" },
+  K: { "bank": "B", "other": "9" },
+  M: { "wall clock": "W", "desktop clock": "D" },
+  N: {
+    "hamper": "H", "bin (shelftop)": "B", "chest": "C",
+    "basket (floor)": "K", "basket (carrying)": "H", // "basket (carrying)" maps to H (hamper) per schema proximity
+    "tower/stand": "T", "cube-collapsible": "U",
+  },
+  P: {
+    "faux shaped box": "B", "chest": "C",
+    "jewelry/music box": "J", "jewellery/music box": "J", // spelling variant
+    "lift-off": "F", "kitchen": "K", "ottoman non-collapsible": "N",
+  },
+  R: { "tray/dish": "T" },
+  S: { "single item holder": "H", "pencil cup": "P", "set": "S", "multi section": "M", "phone stand": "N", "headphone stand": "E" },
+  T: { "perpetual calendar": "C", "deskmat": "M", "paperweight": "W", "sticky note holder": "S", "memo pad": "P" },
+  U: { "monitor stand": "M", "lapdesk": "P" },
+  V: { "door": "D", "rug": "R", "kitchen": "K" },
+  W: { "decor": "D", "tool": "T", "accessory": "A" },
+};
+
+/**
+ * Resolve an MG02 value from the API to a single-character code.
+ * Requires a resolved mg01Code for context (same description can mean different things
+ * under different MG01 categories).
+ */
+export function resolveMg02Code(mg01Code: string | null | undefined, val: string | null | undefined): string | null {
+  if (!val) return null;
+  const trimmed = val.trim();
+  if (trimmed.length === 1) return trimmed; // already a code
+  if (!mg01Code) return null; // can't resolve without context
+  const submap = MG02_DESC_TO_CODE[mg01Code];
+  if (!submap) return null;
+  return submap[trimmed.toLowerCase()] ?? null;
+}
+
+// ── MG03 ────────────────────────────────────────────────────────────────────
+
+/** Reverse map: "mg01:mg02" → { mg03_description_lowercase → mg03_code } */
+const MG03_DESC_TO_CODE: Record<string, Record<string, string>> = {
+  "A:A": {
+    "none": "0", "foil": "1", "shaped": "2", "other embellishment": "8", "other": "9",
+    "embroidery": "B", "diy": "D", "led": "E", "staggered": "G", "hi-gloss": "H",
+    "glitter/sequins/rhinest": "Q", "handpaint": "P", "physical attachment": "Y",
+    "gel/other coat": "W", "gel coat": "W",
+  },
+  "A:S": { "specialty fabric": "N", "metallic": "M", "suede/pu leather": "U", "suede/pu leather/pvc": "U" },
+  "A:G": { "led": "E" },
+  "A:F": { "cross-stitch": "C", "linen/cotton": "L" },
+  "A:M": { "none": "0", "diecut/attachment": "D", "diecut/attach/raised": "D", "led": "E", "glitter/sequins/rhinest": "Q" },
+  "B:F": { "cross-stitch": "C", "linen/cotton": "L", "specialty fabric": "N" },
+  "B:3": { "greyboard frame": "G", "mdf frame": "M", "slits / slats": "S", "slits/slats": "S" },
+  "B:G": {
+    "led infinity": "D", "led backlit": "E",
+    "printed": "F", "printed flat": "F", // "printed flat" treated as "printed"
+    "sbox w glit/foil": "Q", "sbox w attachment": "R", "glass sandwich": "W", "sbox printed": "X",
+  },
+  "B:J": { "bank": "B", "fabric/jersey": "F", "polyresin": "P", "yarn/string": "Y" },
+  "B:M": { "none": "0", "diecut mdf": "C", "mdf frame": "D", "metal frame": "M" },
+  "B:R": {
+    "none": "0", "foil": "1", "collage/paper": "C", "diecut/attachment": "D", "led": "E",
+    "fabric": "F", "handpaint": "H", "mdf gel coat": "M", "natural frame": "N", "matting": "P",
+    "glitter/sequins/rhinest": "Q", "specialty paper": "S", "metallic/holofoil": "T",
+    "shaped/molded frame": "Y",
+  },
+  "C:A": { "none": "0", "attachment": "A", "diecut": "C", "holofoil": "H", "foil": "Q", "specialty paper": "S" },
+  "C:D": { "none": "0" },
+  "C:P": { "none": "0", "diecut": "C", "led": "E", "glow-in-the-dark": "G", "glitter": "Q" },
+  "C:R": { "foam/felt": "F", "mdf": "M" },
+  "C:S": { "door hanger lentic": "3", "door hanger mdf": "D", "glass": "G", "metal sign": "M", "wall hanger mdf": "W" },
+  "C:T": { "led": "D", "suncatcher": "S" },
+  "C:3": { "on mdf": "M", "none": "0" },
+  "C:9": { "cork": "C", "natural": "N" },
+  "D:C": { "none": "0" },
+  "D:H": { "single mdf": "M", "multi mdf": "U" },
+  "D:F": { "none": "0", "cork": "C", "dry-erase": "D", "pinboard": "P", "letterboard": "T" },
+  "D:S": { "mdf": "M", "natural": "N", "plastic": "P", "woven": "W" },
+  "D:M": { "dry-erase/magnetic": "D" },
+  "E:D": { "natural": "N", "plastic": "P", "paper rope": "R" },
+  "E:H": { "banner": "B", "pennant": "P", "tapestry": "T", "scroll": "S" },
+  "E:S": { "banner/bunting/pennant": "B", "clip/photo holder": "C", "string light led": "S" },
+  "E:B": { "led": "D" },
+  "E:6": { "paper": "P" },
+  "F:0": { "mdf": "M" },
+  "F:G": { "none": "0" },
+  "F:M": { "greyboard": "G", "mdf": "M", "natural": "N", "plush/fabric": "P" },
+  "F:E": { "mdf": "M" },
+  "F:W": { "mdf": "M" },
+  "F:C": { "mdf": "M" },
+  "G:C": { "none": "0" },
+  "G:G": { "jewelry": "J" },
+  "G:M": { "none": "0", "foil": "1", "led": "E", "raised/diecut": "R", "glitter": "Q", "paint stroke": "S" },
+  "H:S": { "fabric": "F", "diecut/attachment": "R", "diecut/attach/raised": "R" },
+  "H:C": { "fabric": "F", "diecut/attachment": "R", "diecut/attach/raised": "R" },
+  "H:F": { "12 month collage": "2", "clay/ink": "C" },
+  "J:B": { "ceramic/polyresin": "C" },
+  "J:C": { "holder/polyresin": "R" },
+  "J:P": { "ceramic": "C" },
+  "J:R": { "terracotta": "K" },
+  "J:D": { "etched acrylic": "E", "glass": "G", "plastic": "P" },
+  "J:E": { "dry-erase": "D" },
+  "J:G": { "none": "0" },
+  "J:U": { "woven": "W" },
+  "K:B": { "ceramic": "C", "mdf": "M" },
+  "K:9": { "mug": "M" },
+  "M:W": { "basic plastic": "B", "diecut mdf": "C", "round mdf": "M", "countdown mdf": "N", "metal": "S" },
+  "M:D": { "vintage alarm": "A", "metal": "S" },
+  "N:H": {
+    "oxford+pe coat": "2", "felt": "F", "polymesh": "M", "poly/linen+eva": "N",
+    "pu/plastic+eva": "P", "oxford+greyb": "X", "nonwoven+greyb": "W",
+  },
+  "N:B": { "oxford": "X" },
+  "N:C": { "oxford": "X" },
+  "N:K": { "paper seagrass": "P", "rope": "R" },
+  "N:T": { "steel w nonwoven": "S", "steel w woven": "T" },
+  "N:U": { "nonwoven": "N", "ottoman/oxford": "T" },
+  "P:B": { "greyboard book": "G", "mdf book": "M", "greyboard suitcase": "U" },
+  "P:C": { "greyboard": "G", "emb greyboard": "Q" },
+  "P:J": { "greyboard": "G", "glass": "S" },
+  "P:F": { "emb greyboard": "Q" },
+  "P:K": { "plastic": "P" },
+  "P:N": { "mdf": "M" },
+  "R:T": { "acrylic": "A", "ceramic/polyresin": "C", "glass": "G", "wood": "W" },
+  "S:H": { "paper items": "P", "fabric": "F" },
+  "S:P": { "acrylic": "A", "ceramic/polyresin": "C", "greyboard": "G", "mdf": "M" },
+  "S:S": { "mdf": "M" },
+  "S:M": { "acrylic": "A", "greyboard": "G", "metal": "S" },
+  "S:N": { "mdf": "M", "plastic": "P" },
+  "S:E": { "metal": "S" },
+  "T:C": { "mdf": "M" },
+  "T:M": { "rubber": "R" },
+  "T:W": { "glass": "G" },
+  "T:S": { "ceramic/polyresin": "C" },
+  "T:P": { "ceramic/polyresin": "C" },
+  "U:M": { "none": "0" },
+  "U:P": { "none": "0" },
+  "V:D": {
+    "coir w/ plain print": "C", "coir w/ emboss": "D", "coir diecut": "E",
+    "rubber w/ plain print": "R", "tpe w/ print": "U", "rubber w/ embossed": "Q", "tpe w/ diecut": "T",
+  },
+  "V:R": { "rabbit fur rectang": "A", "rabbit fur diecut": "R", "throw, loop": "T" },
+  "V:K": { "pvc foam": "P" },
+  "W:D": { "birdhouse": "H", "plastic": "P", "stepping stone": "S", "planter": "T", "oxford": "X" },
+  "W:T": { "metal tool set": "8", "thermometer": "T", "watering can": "W" },
+  "W:A": { "glove": "G", "accessory set": "8", "tool&acc set": "8" },
+};
+
+/**
+ * Resolve an MG03 value from the API to a single-character (or single-digit) code.
+ * Requires resolved mg01Code and mg02Code for context.
+ */
+export function resolveMg03Code(
+  mg01Code: string | null | undefined,
+  mg02Code: string | null | undefined,
+  val: string | null | undefined,
+): string | null {
+  if (!val) return null;
+  const trimmed = val.trim();
+  if (trimmed.length === 1) return trimmed; // already a code
+  if (!mg01Code || !mg02Code) return null;
+  const submap = MG03_DESC_TO_CODE[`${mg01Code}:${mg02Code}`];
+  if (!submap) return null;
+  return submap[trimmed.toLowerCase()] ?? null;
+}

--- a/supabase/functions/erp-sync/index.ts
+++ b/supabase/functions/erp-sync/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders, json } from "../_shared/http.ts";
 import { unwrapConfigString } from "../_shared/config-utils.ts";
+import { resolveMg01Code, resolveMg02Code, resolveMg03Code } from "../_shared/mg-codes.ts";
 
 const DEFAULT_ERP_ENDPOINT = "https://api.designflow.app/api/item_master/lib/getApiAllItems";
 const BATCH_SIZE = 100;
@@ -211,9 +212,17 @@ serve(async (req: Request) => {
         const normalizedRows = batch.map((item: any) => {
           const externalId = String(item.itemNum || item.styleNumber || item.itemCode || item.id || `unknown-${i}`);
 
-          const mg01 = item["Product Type ( Material)"] || item["Product Type (Material)"] || item.mg01 || item.merchGroup01 || null;
-          const mg02 = item["Product Sub-Type (Construction)"] || item.mg02 || item.merchGroup02 || null;
-          const mg03 = item["Product Sub-Sub-Type (feature)"] || item["Product Sub-Sub-Type(feature)"] || item.mg03 || item.merchGroup03 || null;
+          // Raw API values — may be letter codes ("A") or full descriptions ("Stretched/Box")
+          const mg01Raw = item["Product Type ( Material)"] || item["Product Type (Material)"] || item.mg01 || item.merchGroup01 || null;
+          const mg02Raw = item["Product Sub-Type (Construction)"] || item.mg02 || item.merchGroup02 || null;
+          const mg03Raw = item["Product Sub-Sub-Type (feature)"] || item["Product Sub-Sub-Type(feature)"] || item.mg03 || item.merchGroup03 || null;
+
+          // Resolve to single-character codes — if the API returned a description,
+          // reverse-look it up to its canonical letter code. If resolution fails,
+          // store null so the item is flagged rather than storing a description in a code field.
+          const mg01Code = resolveMg01Code(mg01Raw);
+          const mg02Code = resolveMg02Code(mg01Code, mg02Raw);
+          const mg03Code = resolveMg03Code(mg01Code, mg02Code, mg03Raw);
 
           const erpDate = item.created_date || item.updatedAt || item.lastModified || null;
 
@@ -222,9 +231,9 @@ serve(async (req: Request) => {
             style_number: item.itemNum || item.styleNumber || null,
             item_description: item.item_name || item.itemDescription || item.description || null,
             mg_category: item.mgCategory || null,
-            mg01_code: mg01,
-            mg02_code: mg02,
-            mg03_code: mg03,
+            mg01_code: mg01Code,
+            mg02_code: mg02Code,
+            mg03_code: mg03Code,
             mg04_code: item.mg04 || item.merchGroup04 || null,
             mg05_code: item.mg05 || item.merchGroup05 || null,
             mg06_code: item.mg06 || item.merchGroup06 || null,
@@ -238,9 +247,14 @@ serve(async (req: Request) => {
             sync_run_id: runId,
             synced_at: new Date().toISOString(),
             raw_mg_fields: {
-              mg01,
-              mg02,
-              mg03,
+              // Original API values (may be descriptions or codes)
+              mg01: mg01Raw,
+              mg02: mg02Raw,
+              mg03: mg03Raw,
+              // Resolved letter codes (null if API value couldn't be matched to schema)
+              mg01_code: mg01Code,
+              mg02_code: mg02Code,
+              mg03_code: mg03Code,
               mg04: item.mg04 || item.merchGroup04,
               mg05: item.mg05 || item.merchGroup05,
               mg06: item.mg06 || item.merchGroup06,


### PR DESCRIPTION
## Summary

- **New `_shared/mg-codes.ts`**: Complete reverse lookup tables (MG01/02/03 description → letter code), case-insensitive, including known API spelling variants. Exports `resolveMg01Code`, `resolveMg02Code`, `resolveMg03Code`.
- **`erp-sync`**: Raw API values (descriptions or codes) are now resolved to single-char letter codes before storage in `mg01_code`/`mg02_code`/`mg03_code`. If a description can't be matched to the schema, `null` is stored. Original API values always preserved in `raw_mg_fields.mg01/mg02/mg03`.
- **`ErpEnrichmentTab`**: `renderMgCell` handles pre-fix DB rows (description in code field, length > 1) and post-fix unresolved items (null code, raw value) both shown in amber. Category derivation guards against non-single-char codes.
- **`erp-browse-handlers`**: Removed dead `ERP_CATEGORY_CUTOFF_DATE`/`legacyItems` logic. Added `unresolved_mg_codes` stat.

## After deploying
Run a **Full Sync** to backfill existing DB rows with proper letter codes.