### PR TITLE
Clean up and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,18 @@ a local file it can't find in history, try to re-apply it, and fail (e.g. "polic
 
 **Never apply via MCP and create a local file in the same step without verifying the timestamps match.**
 
+## ERP Sync — After Changing MG Lookup Tables
+
+`supabase/functions/_shared/mg-codes.ts` contains the reverse lookup maps used by `erp-sync` to resolve API descriptions to letter codes. If this file changes:
+
+1. Redeploy edge functions (GitHub Actions `deploy-supabase.yml`, or push to `main` which triggers it)
+2. In the admin UI (Settings → ERP Enrichment), run a **Full Sync** to re-process all existing rows
+3. After the sync, verify the "Unresolved MG Codes" stat card is 0 or matches expected count
+
+Similarly, if `src/lib/mg-lookup.ts` (the frontend forward maps) changes, deploy the frontend.
+
+Both files must agree on the MerchGroup schema — if new MG01/02/03 codes are added to the CSV, update both files in the same PR.
+
 ## Versioning
 
 Whenever changes are made to `apps/bridge-agent/`, bump `apps/bridge-agent/package.json` version as part of the same commit:

--- a/docs/ERP_ENRICHMENT_PLAN.md
+++ b/docs/ERP_ENRICHMENT_PLAN.md
@@ -1,363 +1,136 @@
-# ERP Enrichment Pipeline — Implementation Plan
+# ERP Integration — Current State
+
+> This document replaced the original implementation plan (now fully built). It describes how the ERP pipeline actually works as of May 2025.
+
+---
 
 ## Overview
 
-Add an ERP-driven enrichment pipeline to PopDAM that:
-1. Ingests product data from the DesignFlow ERP API
-2. Maps SKU/MG codes to product attributes using deterministic rules
-3. Classifies legacy items (missing `mgCategory`) into 7 product categories using AI
-4. Applies enrichment to existing `assets` and `style_groups` records
-5. Provides admin UI for configuration, monitoring, and review
+PopDAM syncs product master data from the DesignFlow ERP API into a local `erp_items_current` table, enriches assets and style groups with that data, and provides an admin UI to browse, filter, and review ERP items.
 
 ---
 
-## Phase 1: Schema — ERP Staging & Mapping Tables
+## 1. Database Tables
 
-### New Tables (via migration)
+### `erp_items_current`
+Latest normalized row per ERP item. Upserted on every sync.
 
-#### `erp_items_raw`
-Immutable audit snapshots of every ERP API response row.
-```
-id              uuid PK DEFAULT gen_random_uuid()
-external_id     text NOT NULL          -- ERP item identity (e.g. styleNumber or itemCode)
-raw_payload     jsonb NOT NULL         -- full ERP row as-is
-sync_run_id     uuid FK erp_sync_runs(id)
-fetched_at      timestamptz DEFAULT now()
-```
-Index: `btree(external_id)`, `btree(sync_run_id)`
+Key columns:
+- `external_id` — unique ERP item identifier
+- `style_number` — parsed SKU
+- `item_description` — product name from ERP
+- `mg_category` — category string from ERP API (e.g. "Wall", "Storage") — may be null
+- `mg01_code`, `mg02_code`, `mg03_code` — **single-character letter/digit codes** (e.g. "A", "B", "0")
+- `raw_mg_fields` — JSONB storing original API values: `mg01`/`mg02`/`mg03` contain the raw API text (descriptions for post-May-2025 items, letter codes for older items), plus `mg01_code`/`mg02_code`/`mg03_code` for the resolved codes
+- `size_code`, `licensor_code`, `property_code`, `division_code`, `prepack_code`, `prepack_codes`
+- `erp_updated_at` — ERP's own last-modified date (used as "Created Date" in the browser)
+- `synced_at` — when we last wrote this row
+- `dismissed` — soft-hide from browser
 
-#### `erp_items_current`
-Latest normalized row per ERP item. Upserted on each sync.
-```
-id                  uuid PK DEFAULT gen_random_uuid()
-external_id         text UNIQUE NOT NULL
-style_number        text                -- parsed/normalized SKU
-item_description    text
-mg_category         text                -- from ERP (null for legacy items)
-mg01_code           text
-mg02_code           text
-mg03_code           text
-size_code           text
-licensor_code       text
-property_code       text
-division_code       text
-erp_updated_at      timestamptz         -- ERP's own last-modified
-synced_at           timestamptz DEFAULT now()
-sync_run_id         uuid FK erp_sync_runs(id)
-source_system       text DEFAULT 'designflow'
-created_at          timestamptz DEFAULT now()
-updated_at          timestamptz DEFAULT now()
-```
-Indexes: `btree(style_number)`, `btree(mg_category)`, `btree(synced_at)`
+### `erp_items_raw`
+Immutable snapshot of every ERP API response row, one row per sync run per item.
 
-#### `erp_sync_runs`
-Job metadata for each sync execution.
-```
-id              uuid PK DEFAULT gen_random_uuid()
-status          text NOT NULL DEFAULT 'running'   -- running, completed, failed
-started_at      timestamptz DEFAULT now()
-ended_at        timestamptz
-total_fetched   int DEFAULT 0
-total_upserted  int DEFAULT 0
-total_errors    int DEFAULT 0
-error_samples   jsonb DEFAULT '[]'
-run_metadata    jsonb DEFAULT '{}'       -- watermark, mode, etc.
-created_by      text                     -- 'admin-ui', 'cron', 'bulk-job-runner'
-```
+### `erp_sync_runs`
+Metadata per sync run: status, start/end times, fetched/upserted/error counts, watermark.
 
-#### `product_category_predictions`
-AI classification results for legacy items missing `mgCategory`.
-```
-id                  uuid PK DEFAULT gen_random_uuid()
-erp_item_id         uuid FK erp_items_current(id) ON DELETE CASCADE
-external_id         text NOT NULL
-predicted_category  text NOT NULL        -- one of 7 categories
-confidence          real NOT NULL        -- 0.0–1.0
-rationale           text                 -- short AI explanation
-classification_source text NOT NULL      -- 'erp', 'rule', 'ai'
-ai_model            text                 -- e.g. 'google/gemini-3-flash-preview'
-ai_prompt_version   text                 -- e.g. 'v1'
-status              text DEFAULT 'pending' -- pending, approved, rejected, auto_applied
-reviewed_by         uuid                 -- admin who approved/rejected
-reviewed_at         timestamptz
-input_context       jsonb                -- what was sent to AI
-created_at          timestamptz DEFAULT now()
-```
-Index: `btree(status)`, `btree(erp_item_id)`
-
-#### `erp_enrichment_log`
-Per-field provenance tracking for applied enrichments.
-```
-id              uuid PK DEFAULT gen_random_uuid()
-target_type     text NOT NULL           -- 'asset' or 'style_group'
-target_id       uuid NOT NULL
-field_name      text NOT NULL
-old_value       text
-new_value       text
-source          text NOT NULL           -- 'erp', 'rule', 'ai', 'manual'
-confidence      real
-run_id          uuid
-applied_at      timestamptz DEFAULT now()
-```
-Index: `btree(target_id)`, `btree(run_id)`
-
-### RLS Policies
-- All new tables: admin-only write, authenticated read
-- `erp_items_raw`: admin read-only (no browser exposure of full payloads)
+### `product_category_predictions`
+AI classification results for items missing `mg_category`. Statuses: `pending`, `auto_applied`, `approved`, `rejected`, `unclassifiable`.
 
 ---
 
-## Phase 2: ERP Sync Edge Function (`erp-sync`)
+## 2. ERP Sync Edge Function (`erp-sync`)
 
-### Endpoint
-`POST /functions/v1/erp-sync` (called by admin-api or bulk-job-runner)
+**Endpoint**: `POST /functions/v1/erp-sync`
 
-### Logic
-1. Create `erp_sync_runs` row with status='running'
-2. Fetch `https://api.item.designflow.app/lib/getApiAllItems`
-   - No auth required
-   - Full dataset returned in single response (no pagination from API)
-   - Response is a JSON array of items
-3. Validate response shape with Zod
-4. For each item:
-   - Insert into `erp_items_raw` (immutable snapshot)
-   - Upsert into `erp_items_current` (keyed on `external_id`)
-5. Update `erp_sync_runs` with counts
-6. Support batched processing (100 items per DB upsert)
+**Modes**:
+- **Incremental** (default): fetches items since the watermark date (`ERP_LAST_SYNC_DATE` in `admin_config`)
+- **Full**: fetches entire dataset (no date filter)
 
-### Retry/Safety
-- 30s fetch timeout
-- Run locking: check for existing `running` sync run before starting
-- Idempotent: re-running overwrites `erp_items_current` safely
+**MG Code Resolution** (`supabase/functions/_shared/mg-codes.ts`):
 
-### Integration with bulk-job-runner
-- Add `erp-sync` to `OP_ACTIONS` map
-- Single-batch operation (fetch all → process → done)
-- Or cursor-based if ERP response is very large
+The DesignFlow API changed format around May 2025. New items return full descriptions in MG fields ("Stretched/Box", "Canvas") rather than letter codes ("A", "A"). The sync function resolves these:
 
-### Config
-Store in `admin_config`:
-- `ERP_SYNC_CONFIG`: `{ endpoint, enabled, last_sync_at }`
+1. `resolveMg01Code(rawApiValue)` — single-char → pass through; multi-char → reverse-lookup against the MerchGroup CSV schema; unknown → null
+2. `resolveMg02Code(mg01Code, rawApiValue)` — same, context-aware per MG01
+3. `resolveMg03Code(mg01Code, mg02Code, rawApiValue)` — same, context-aware per MG01+MG02
+
+Matching is case-insensitive. Known API spelling variants are included (e.g. "Jewellery/Music Box" → "J", "diecut/attach/raised" → "D", "Suede/PU Leather/PVC" → "U").
+
+If a description can't be matched to any known schema code, `null` is stored in the code field and the raw value is preserved in `raw_mg_fields`. This surfaces as an amber "unresolved" indicator in the browser.
+
+**After any change to `mg-codes.ts`**: redeploy `erp-sync` and run a Full Sync to backfill existing rows.
+
+**Safety**:
+- Run lock: rejects if a sync is already running
+- 120s fetch timeout
+- Watermark updated after successful completion
 
 ---
 
-## Phase 3: Mapping Engine
+## 3. MerchGroup Schema (`src/lib/mg-lookup.ts` and `_shared/mg-codes.ts`)
 
-### Location
-`supabase/functions/_shared/erp-mapper.ts`
+Two related files implement the MerchGroup Rework schema (effective May 10, 2025):
 
-### Pipeline (precedence order)
-1. **ERP direct fields** — if `mg_category` is populated, use it
-2. **SKU deterministic rules** — existing `sku-parser.ts` logic (MG01→category mapping)
-3. **Spreadsheet overrides** — stored in `admin_config` as `SKU_MAPPING_OVERRIDES`
-4. **AI fallback** — only when above methods fail
+| File | Purpose | Used By |
+|------|---------|---------|
+| `src/lib/mg-lookup.ts` | Forward maps: code → description. Used for UI display. | Frontend (ErpEnrichmentTab) |
+| `supabase/functions/_shared/mg-codes.ts` | Reverse maps: description → code. Used during sync. | erp-sync edge function |
 
-### Output
-For each ERP item, produce:
-```typescript
-interface ResolvedAttributes {
-  product_category: string;       // one of 7 categories
-  mg01_code: string; mg01_name: string;
-  mg02_code: string; mg02_name: string;
-  mg03_code: string; mg03_name: string;
-  size_code: string; size_name: string;
-  licensor_code: string; licensor_name: string | null;
-  property_code: string; property_name: string | null;
-  division_code: string; division_name: string;
-  is_licensed: boolean;
-  classification_source: 'erp' | 'rule' | 'ai';
-  confidence: number;
-}
-```
-
-### Confidence hierarchy
-- ERP direct: confidence = 1.0
-- SKU rule match: confidence = 0.95
-- AI: confidence from model response (0.0–1.0)
-
-### Existing value preservation
-- Only overwrite if new confidence > existing confidence
-- Unless `force_overwrite` flag is set in the enrichment job params
+The schema has 3 levels: MG01 (product type, 18 categories A–W), MG02 (construction, varies per MG01), MG03 (feature, varies per MG01+MG02). The `mgCategory` field (Wall, Tabletop, Clock, Storage, Workspace, Floor, Garden) is derived from MG01 via the `MG01_CATEGORY` map.
 
 ---
 
-## Phase 4: AI Classification for Legacy Items
+## 4. Admin UI (`src/components/settings/ErpEnrichmentTab.tsx`)
 
-### Trigger
-Items in `erp_items_current` where `mg_category IS NULL` AND deterministic rules cannot resolve.
+### ERP Items Browser
+Sortable, filterable table showing all ERP items. Features:
+- Search by style # or description
+- Filter by Created Date range
+- Filter by style #/description max character length (for finding junk entries)
+- Show/hide dismissed items
+- Batch dismiss
 
-### Implementation
-- New admin-api action: `classify-erp-categories`
-- Calls Lovable AI gateway (`google/gemini-3-flash-preview`) via tool calling
-- Batch: process 10 items per invocation
+**MG column display**:
+- MG01/02/03 show the human-readable description (from `getMg01Desc(code)` or raw API value), with the letter code in a tooltip
+- Items where mg01_code is null but the API returned a description show it in **amber** — the description didn't match any schema entry and may need ERP correction
+- Pre-fix rows (description stored in code field, `length > 1`) also display in amber until a Full Sync re-processes them
+- Category: shows `mg_category` from API; if null, derives from MG01 code via `getMgCategory()` in italic
 
-### AI Input
-```json
-{
-  "item_description": "...",
-  "style_number": "...",
-  "known_mg_fields": { "mg01": "...", "mg02": "..." },
-  "existing_tags": ["..."]
-}
-```
+### Stats Dashboard
+Cards: Total ERP items, Has mgCategory, No mgCategory, Rule-Classified, AI-Classified, Needs AI, Pending Review, SKU Matched, Unmatched SKUs. If any items have unresolved MG codes (amber), an additional "Unresolved MG Codes" card appears.
 
-### AI Output (via tool calling)
-```json
-{
-  "category": "Wall",
-  "confidence": 0.87,
-  "rationale": "Product description mentions 'canvas wall art' and MG01=A maps to stretched/box category"
-}
-```
-
-### Guardrails
-- Confidence < 0.65 → `needs_review` (not auto-applied)
-- Confidence ≥ 0.65 → `auto_applied` (written to `product_category_predictions`)
-- All predictions saved regardless of confidence
-
-### Admin-api action integration
-- `classify-erp-categories`: cursor-based, processes batch of unclassified items
-- Integrates with bulk-job-runner pattern
+### Review Queue
+Table of `product_category_predictions` where AI confidence was below threshold. Actions: Approve, Override (select different category), Reject, Bulk reject.
 
 ---
 
-## Phase 5: Apply Enrichment to DAM Records
+## 5. Category Classification (AI)
 
-### Admin-api action: `apply-erp-enrichment`
-Modes:
-- `dry-run`: returns counts of what would change (no writes)
-- `apply`: upsert only when confidence > existing
-- `apply-force`: overwrite regardless of confidence
+Items where `mg_category` is null AND deterministic lookup from MG01 code fails are eligible for AI classification.
 
-### Logic
-1. Join `erp_items_current` + `product_category_predictions` → resolved attributes
-2. Match to `assets` by normalized SKU
-3. Match to `style_groups` by SKU
-4. Batch update (50 per batch)
-5. For each field changed, write to `erp_enrichment_log`
-6. After asset updates, refresh style_group summary fields
-
-### Cursor-based, resumable
-- Uses same `usePersistentOperation` + `bulk-job-runner` pattern
-- Cursor = offset into matched items
-- Progress: `{ matched, updated, skipped, total }`
-
-### Safety
-- Never deletes assets or groups
-- Preserves existing values when new confidence is lower
-- All changes logged in `erp_enrichment_log`
+- Trigger: `classify-erp-categories` action on admin-api
+- Confidence < 0.65 → status `pending` (Review Queue)
+- Confidence ≥ 0.65 → status `auto_applied`
+- All predictions stored regardless of confidence
 
 ---
 
-## Phase 6: Admin UI
+## 6. Known Data Quality Issues (Post-May 2025 API Items)
 
-### New Settings Tab: "ERP Enrichment"
+From a DB audit of post-May-10-2025 items:
 
-#### Section 1: ERP Sync Configuration
-- Endpoint URL (read-only, from config)
-- Last sync: timestamp, status, counts
-- "Run Sync Now" button (triggers erp-sync via persistent operation)
-- Sync history (last 5 runs from `erp_sync_runs`)
-
-#### Section 2: Enrichment Controls
-- "Dry Run" button → shows preview of changes
-- "Apply Enrichment" button → runs apply-erp-enrichment
-- "Apply (Force Overwrite)" button → with confirmation dialog
-- Progress bar during operation
-
-#### Section 3: Quality Dashboard
-Cards showing:
-- Total ERP items synced
-- Matched by deterministic rules (count)
-- AI-classified (count, with confidence breakdown)
-- Low-confidence pending review (count)
-- Unmatched SKUs (count)
-
-#### Section 4: Review Queue
-Table of `product_category_predictions` where `status = 'pending'` and confidence < threshold:
-- Columns: style_number, description, predicted_category, confidence, rationale
-- Actions: Approve / Override (select different category) / Reject
-- Bulk approve button
-
-### Diagnostics Integration
-Add cards to existing Diagnostics tab:
-- Last ERP sync status + duration + counts
-- Last enrichment run status + changed assets/groups
-- Error samples with retry button
+| Issue | Detail |
+|-------|--------|
+| 1 item with old letter-code format | `SDX00WBLR01S` — uses MG01="S"/MG02="D"/MG03="DX", mg_category=null; likely ERP data entry error |
+| 3 items with null mg_category | API didn't return a category; needs ERP investigation |
+| Several description mismatches vs CSV | e.g. "Printed Flat" (CSV: "Printed"), "Metallic Canvas" (not in CSV), case variants — these store null in code fields and show amber in browser |
 
 ---
 
-## Phase 7: Testing
+## 7. Rollout Checklist (For Future Reference)
 
-### Unit Tests (vitest)
-1. SKU parsing edge cases (old vs new MG structure)
-2. Category enum validation (only 7 valid values)
-3. Confidence threshold behavior (auto-apply vs needs_review)
-4. Mapping precedence (ERP > rule > AI)
-
-### Integration Tests (edge function tests)
-1. ERP sync: fetch → stage → normalize
-2. Enrichment: staged data → asset/group updates
-3. Interrupted run resume
-4. Dry-run returns correct counts without writes
-
-### Fixtures
-- Sample old-format items (no mgCategory)
-- Sample new-format items (with mgCategory)
-- Edge cases: unknown MG codes, missing fields
-
----
-
-## Phase 8: Rollout
-
-### Feature Flag
-Store in `admin_config`: `ERP_ENRICHMENT_ENABLED` (default: false)
-
-### Rollout Steps
-1. Deploy schema migrations
-2. Enable sync (set flag, run first sync)
-3. Review synced data in admin UI
-4. Run dry-run enrichment, review changes
-5. Run AI classification on legacy items
-6. Review low-confidence predictions
-7. Apply enrichment
-
-### Operator Runbook (in docs/)
-- How to run first sync
-- How to review low-confidence categories
-- How to retry failed runs
-- How to force-overwrite specific items
-
----
-
-## Implementation Order
-
-| Step | What | Files |
-|------|------|-------|
-| 1 | Schema migration (all new tables) | `supabase/migrations/` |
-| 2 | `erp-sync` edge function | `supabase/functions/erp-sync/index.ts` |
-| 3 | `_shared/erp-mapper.ts` | `supabase/functions/_shared/erp-mapper.ts` |
-| 4 | Admin-api actions: `erp-sync-status`, `classify-erp-categories`, `apply-erp-enrichment` | `supabase/functions/admin-api/index.ts` |
-| 5 | Bulk-job-runner: add ERP operations | `supabase/functions/bulk-job-runner/index.ts` |
-| 6 | AI classification edge function integration | `supabase/functions/ai-tag/index.ts` or new |
-| 7 | Admin UI: ErpEnrichmentTab | `src/components/settings/ErpEnrichmentTab.tsx` |
-| 8 | Review queue UI | `src/components/settings/ErpReviewQueue.tsx` |
-| 9 | Diagnostics cards | `src/components/settings/DiagnosticsTab.tsx` |
-| 10 | Tests + fixtures | `src/test/`, edge function tests |
-| 11 | Documentation | `docs/ERP_ENRICHMENT.md` |
-
----
-
-## Open Questions (Need Your Input Before Implementation)
-
-1. **ERP API response shape**: I need to inspect the actual JSON structure. Can you share a sample item from the API response? Key fields I need to identify:
-   - What is the unique item identifier field? (`styleNumber`? `itemCode`? `id`?)
-   - What field contains `mgCategory`?
-   - What fields contain MG01/02/03 codes?
-   - What field has the product description for AI classification?
-
-2. **Spreadsheet mapping**: You mentioned a spreadsheet that defines MG code relationships. Can you upload it so I can build the deterministic rules?
-
-3. **ERP item count**: Roughly how many items does the API return? This affects whether we need cursor-based processing or can handle it in a single batch.
-
-4. **Incremental sync**: Does the ERP API support filtering by last-modified date, or is it always a full dump?
+When deploying changes to `mg-codes.ts` or `erp-sync`:
+1. Deploy edge functions via GitHub Actions
+2. In ERP Enrichment admin UI → run **Full Sync**
+3. Verify "Unresolved MG Codes" stat is 0 or expected count
+4. Check amber rows in browser — these need ERP correction upstream

--- a/docs/MODEL_RULES.md
+++ b/docs/MODEL_RULES.md
@@ -1,135 +1,52 @@
-\# MODEL \& EXECUTION RULES
+# AI Model Usage Rules
 
-
-
-\## 1. Primary Model
-
-\- \*\*ALWAYS\*\* use \*\*GPT-5.2\*\* for all architectural decisions, database migrations, and complex logic.
-
-\- Do NOT use Gemini Flash for backend or connectivity tasks.
-
-
-
-\## 2. Chain of Thought (CoT)
-
-\- Before implementing any change, summarize your understanding of the current state.
-
-\- If a task involves more than 3 steps, output a PLAN first and wait for approval.
-
-
-
-\## 3. Stability Guardrails
-
-\- \*\*No Fix-on-Fix:\*\* If a bug persists after two attempts, STOP. Re-read SCHEMA.md and PATH\_UTILS.md before trying again.
-
-\- \*\*Fail-Fast:\*\* Never return a success message if a file scan returns 0 results. Treat 0 results as a potential permission or path error.
-
-
-
-\# EXECUTION RULES (Anti-Amnesia + Anti-Chaos)
-
-
-
-This file exists to prevent “looping,” config drift, and fragile fix-on-fix behavior.
-
-
-
-These rules apply to any AI builder working on this repo.
-
-
+This document covers two distinct things: (1) which AI models are used inside the PopDAM system for product classification, and (2) execution rules for AI coding assistants working on this codebase.
 
 ---
 
+## 1. Models Used Inside PopDAM
 
+### Product Category Classification (`ai-tag` edge function)
+- Uses Claude via the Anthropic API (configured in admin_config or environment)
+- Classifies ERP items into product categories when deterministic rules can't resolve them
+- Confidence < 0.65 → status `pending` (requires human review in the Review Queue)
+- Confidence ≥ 0.65 → status `auto_applied`
 
-\## 1) Read Order (Every Session)
-
-Before implementing changes:
-
-1\) Read PROJECT\_BIBLE.md
-
-2\) Read the relevant doc(s): SCHEMA.md, PATH\_UTILS.md, API\_CONTRACTS.md, DEPLOYMENT.md
-
-3\) State which Non-Negotiables apply to the task
-
-
+### AI Tagging
+- Used for generating asset descriptions and tags from thumbnails
+- Configured via the AI model setting in admin_config
 
 ---
 
+## 2. Execution Rules for AI Coding Assistants
 
+### Read Before Coding
+Before implementing any change, read:
+1. `PROJECT_BIBLE.md` — non-negotiable rules (this always wins in a conflict)
+2. The relevant doc(s): `SCHEMA.md`, `PATH_UTILS.md`, `API_CONTRACTS.md`, `DEPLOYMENT.md`
+3. State which rules apply to the task before writing code
 
-\## 2) Change Discipline (Stability)
+### Change Discipline
+- Prefer small, focused diffs over refactors
+- If a task touches DB schema or API shapes, update the matching doc in the same commit
+- No fix-on-fix: if the same bug persists after two attempts, stop and re-read the relevant docs before trying a third approach
+- Don't add features, error handling, or abstractions beyond what was asked
 
-\- One change per iteration.
+### Fail-Fast Rules
+- If a scan reports `files_checked = 0`, treat it as an error unless the scan roots were explicitly validated as empty
+- Never return a success response when a core operation processed nothing
+- Timestamps must always come from the filesystem (agent-supplied), never from `now()` or defaults
 
-\- Prefer small diffs over refactors.
-
-\- If a task touches DB schema or API shapes, update the matching docs in the same commit.
-
-
-
-After each change:
-
-\- Show a diff summary (what files changed and why)
-
-\- Confirm:
-
-&nbsp; - no hardcoded host/share strings
-
-&nbsp; - no client-side filtering of large asset lists
-
-&nbsp; - timestamps come from filesystem (agent-supplied)
-
-&nbsp; - pagination remains server-side
-
-
+### Truthfulness
+- Don't claim something was tested unless the tool actually ran it
+- If tests exist, run them; otherwise say "not executed" explicitly
 
 ---
 
+## 3. Golden Rule (Repeated Here For Emphasis)
 
+The DAM must **never** modify file timestamps (`mtime`/`birthtime`) on source art files.
 
-\## 3) “No Fix-on-Fix” Rule
+Before touching any file, record its original timestamps. After, verify and restore if changed. If restoration fails, halt processing and report a critical error.
 
-If the same bug persists after two attempts:
-
-\- STOP
-
-\- Re-read PROJECT\_BIBLE.md + PATH\_UTILS.md + SCHEMA.md
-
-\- Propose a different approach (or reduce scope)
-
-
-
----
-
-
-
-\## 4) Fail-Fast Rule (Scanner)
-
-If a scan reports:
-
-\- `files\_checked = 0`
-
-treat as an error unless roots were explicitly validated and truly contain zero files.
-
-
-
-Never silently report success on a scan that processed nothing.
-
-
-
----
-
-
-
-\## 5) Truthfulness Rule
-
-Do not claim things were tested unless the tool actually ran them.
-
-If tests exist, run them; otherwise say “not executed” explicitly.
-
-
----
-
-## 6) Golden Rule: File Date Preservation
-The DAM must NEVER modify file timestamps (mtime/birthtime) on source art files. Before reading any file, record original timestamps; after, verify and restore if changed. If restoration fails, HALT processing and report a critical error. This is a non-negotiable project invariant. See PROJECT_BIBLE.md §15.
+This is the single most important invariant in the entire system. See `PROJECT_BIBLE.md §15` for full details.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -431,16 +431,34 @@ After tagging, a bulk operation copies AI tags from the primary tagged asset to 
 
 ### Data flow
 1. **Sync**: Admin triggers ERP sync → `erp-sync` edge function fetches from DesignFlow API → stores raw + normalized data
-2. **Enrichment**: `apply-erp-enrichment` matches ERP items to assets by style number (SKU prefix) → copies division, licensor, property, MG codes to assets and style groups
-3. **AI Classification**: For items missing `mgCategory` (legacy products), Gemini classifies them into 7 product categories based on item description, style number, and context
+2. **AI Classification**: For items missing `mg_category`, Claude classifies them into product categories based on item description and MG codes
+3. **Browse**: Admins review ERP items in the ERP Items Browser — sortable/filterable table with MG code display, date filtering, and dismiss support
+
+### MG Code Architecture (important)
+
+The DesignFlow API changed format around May 2025. New items return **full text descriptions** in MG fields ("Stretched/Box", "Canvas", "Foil") instead of single-letter codes ("A", "A", "1").
+
+The `erp-sync` function normalises this using reverse lookup tables in `supabase/functions/_shared/mg-codes.ts`:
+- Single-char API values → already a code, stored as-is
+- Multi-char API values → reverse-looked up to canonical letter code via the MerchGroup CSV schema
+- Unknown descriptions → stored as `null` in the code field; raw value preserved in `raw_mg_fields`
+
+**Result**: `mg01_code`/`mg02_code`/`mg03_code` always hold single-character codes (or null). The raw API value is always in `raw_mg_fields.mg01`/`.mg02`/`.mg03` for display.
+
+The frontend (`src/lib/mg-lookup.ts`) contains the forward maps (code → description) for display. The edge function (`_shared/mg-codes.ts`) contains the reverse maps (description → code) used during sync. They must be kept in sync if the MerchGroup schema changes.
 
 ### Confidence thresholds
-- ≥ 65%: Auto-applied to the ERP item
-- < 65%: Queued in `product_category_predictions` for human review
-- Items can have "custom instructions" and few-shot examples to improve AI accuracy
+- ≥ 65%: Auto-applied (`auto_applied` status)
+- < 65%: Queued in `product_category_predictions` for human review (`pending` status)
 
-### Date guard
-`mgCategory` from ERP is only used for items created **after May 9, 2025**. Older items rely on AI classification or manual assignment.
+### Admin UI
+The **ERP Items Browser** (Settings → ERP Enrichment tab) shows all ERP items with:
+- MG01/02/03 displayed as descriptions (letter code shown on hover)
+- Amber highlighting for unresolved descriptions (not in schema — ERP data needs correction)
+- Date range filter on `erp_updated_at`
+- Review Queue for AI predictions awaiting human approval
+
+For full details see `docs/ERP_ENRICHMENT_PLAN.md`.
 
 ---
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -163,7 +163,7 @@ Invitation-only access model:
 - user_roles: `user_id uuid`, `role text`, `UNIQUE(user_id, role)`
 - invitations: `id uuid PK`, `email text UNIQUE NOT NULL`, `role text DEFAULT 'user'`, `invited_by uuid NULL`, `created_at`, `accepted_at NULL`
 
-### 2.12 admin_config
+### 2.13 admin_config
 - `key text PK`
 - `value jsonb NOT NULL`
 - `updated_at timestamptz DEFAULT now()`
@@ -172,9 +172,63 @@ Invitation-only access model:
 Stores:
 - `THUMBNAIL_MIN_DATE`
 - `SCAN_MIN_DATE`
+- `ERP_LAST_SYNC_DATE` (watermark for incremental ERP sync)
+- `ERP_SYNC_ENDPOINT` (override ERP API URL)
+- `BULK_OPERATIONS` (JSONB blob tracking all persistent operation state)
 - DO Spaces base URL
 - taxonomy endpoints
 - NAS mapping keys (host/ip/share/mount root)
+
+### 2.14 ERP Tables
+
+#### `erp_sync_runs`
+Metadata per sync execution.
+- `id uuid PK`, `status text` (running/completed/failed), `started_at`, `ended_at`
+- `total_fetched int`, `total_upserted int`, `total_errors int`, `error_samples jsonb`
+- `run_metadata jsonb` (sync_mode, start_date, end_date), `created_by text`
+
+#### `erp_items_current`
+Latest normalized row per ERP item. Upserted on each sync.
+- `id uuid PK`, `external_id text UNIQUE NOT NULL`
+- `style_number text`, `item_description text`
+- `mg_category text` — category from ERP API ("Wall", "Storage", etc.) — may be null
+- `mg01_code text`, `mg02_code text`, `mg03_code text` — **single-character letter/digit codes** resolved from the API
+- `mg04_code`, `mg05_code`, `mg06_code` — additional MG levels (rarely populated)
+- `size_code`, `licensor_code`, `property_code`, `division_code`, `prepack_code`, `prepack_codes text[]`
+- `erp_updated_at timestamptz` — ERP's own last-modified (used as "Created Date" in the browser)
+- `synced_at timestamptz`, `sync_run_id uuid FK erp_sync_runs`
+- `raw_mg_fields jsonb` — original API values: `mg01`/`mg02`/`mg03` (may be descriptions or codes), plus `mg01_code`/`mg02_code`/`mg03_code` (resolved) and other metadata fields
+- `dismissed boolean DEFAULT false` — soft-hide from browser
+
+#### `erp_items_raw`
+Immutable snapshot of every ERP API response row.
+- `id uuid PK`, `external_id text`, `raw_payload jsonb`, `sync_run_id uuid FK`, `fetched_at timestamptz`
+
+#### `product_category_predictions`
+AI classification results for ERP items missing `mg_category`.
+- `id uuid PK`, `external_id text`, `erp_item_id uuid FK erp_items_current`
+- `predicted_category text`, `confidence real`, `rationale text`
+- `classification_source text` (erp/rule/ai), `ai_model text`
+- `status text` (pending/auto_applied/approved/rejected/unclassifiable)
+- `reviewed_by uuid`, `reviewed_at timestamptz`, `input_context jsonb`
+
+### 2.15 Hygiene & Style Guide Tables
+
+#### `hygiene_findings`
+File naming/structure issues found during Windows Agent scans.
+- `id uuid PK`, `scan_session_id uuid`, `file_path text`, `finding_type text`, `detail jsonb`, `found_at timestamptz`
+
+#### `style_guide_crawl_runs`
+Metadata for each licensor style guide crawl run.
+- `id uuid PK`, `status text`, `agent_id text`, `started_at`, `completed_at`, `files_found int`, `error_message text`
+
+#### `style_guide_files`
+Crawled style guide PDFs and images from licensors.
+- `id uuid PK`, `crawl_run_id uuid FK`, `relative_path text`, `file_type text`, `thumbnail_url text`, `metadata jsonb`, `found_at timestamptz`
+
+#### `tiff_optimization_queue`
+Queue for TIFF compression jobs run by the Windows Agent.
+- `id uuid PK`, `asset_id uuid FK assets`, `status queue_status`, `claimed_by text`, `claimed_at`, `completed_at`, `error_message text`
 
 ---
 


### PR DESCRIPTION
Brings all docs up to date with the current codebase.

- **MODEL_RULES.md**: Rewrote — removed escaped markdown artifacts and the bogus "GPT-5.2" reference; reorganised into actual AI models used in PopDAM, coding assistant rules, and golden rule reminder.
- **ERP_ENRICHMENT_PLAN.md**: Replaced stale pre-implementation plan with a current-state reference doc covering actual tables, erp-sync, mg-codes.ts architecture, UI behaviour, known data quality issues, and deployment checklist.
- **SCHEMA.md**: Fixed duplicate section 2.12; added missing tables (erp_sync_runs, erp_items_current with all columns, erp_items_raw, product_category_predictions, hygiene_findings, style_guide_crawl_runs, style_guide_files, tiff_optimization_queue) and missing admin_config keys.
- **ONBOARDING.md §14**: Rewrote ERP section to explain API format change, mg-codes.ts reverse lookup, raw_mg_fields dual-storage, and amber unresolved indicator.
- **CLAUDE.md**: Added section on what to do after changing MG lookup tables (redeploy + Full Sync).