### PR TITLE
Update docs to reflect recent architecture changes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,25 @@ Hard rule: never mix admin + agent routes in one function.
   - raw key shown once on creation
   - raw key never returned again
 
+### Edge function CORS
+All edge functions must use `corsServe()` from `supabase/functions/_shared/http.ts` instead of importing `serve` + static `corsHeaders` directly. `corsServe()`:
+- Handles OPTIONS preflights automatically
+- Validates the request `Origin` against an allowlist (`*.designflow.app`, `*.lovable.app`, localhost)
+- Rewrites `Access-Control-Allow-Origin` on every response with the specific allowed origin (not `*`)
+- Rejects unauthorized origins by omitting CORS headers entirely
+
+```typescript
+import { corsServe, json, err } from "../_shared/http.ts";
+
+corsServe(async (req: Request) => {
+  // no OPTIONS check needed
+  return json({ ok: true });
+});
+```
+
+### Admin query endpoint security
+The `run-query` action in admin-api restricts queries to `SELECT` only (no `WITH` CTEs — the `execute_readonly_query` DB function enforces read-only at the transaction level, but removing the CTE prefix at the gateway prevents any bypass attempts).
+
 ---
 
 ## 5) Deployment (Non-Negotiable)

--- a/docs/MODEL_RULES.md
+++ b/docs/MODEL_RULES.md
@@ -1,20 +1,28 @@
 # AI Model Usage Rules
 
-This document covers two distinct things: (1) which AI models are used inside the PopDAM system for product classification, and (2) execution rules for AI coding assistants working on this codebase.
+This document covers two distinct things: (1) which AI models are used inside the PopDAM system, and (2) execution rules for AI coding assistants working on this codebase.
 
 ---
 
 ## 1. Models Used Inside PopDAM
 
-### Product Category Classification (`ai-tag` edge function)
-- Uses Claude via the Anthropic API (configured in admin_config or environment)
-- Classifies ERP items into product categories when deterministic rules can't resolve them
-- Confidence < 0.65 → status `pending` (requires human review in the Review Queue)
-- Confidence ≥ 0.65 → status `auto_applied`
+### Asset Thumbnail Tagging (`ai-tag` edge function)
+- Uses **Google Gemini** (vision-capable model) to analyze thumbnail images
+- The specific model is **configurable** via `AI_MODELS` in admin_config — `ai-tag` finds the first entry with `provider: "google"` and `capabilities` including `"vision"`
+- Falls back to `gemini-2.5-flash-preview-04-17` if `AI_MODELS` config is absent or has no qualifying model
+- To change the model: update the `AI_MODELS` array in Settings → Admin Config
 
-### AI Tagging
-- Used for generating asset descriptions and tags from thumbnails
-- Configured via the AI model setting in admin_config
+### PDF Text Extraction (`pdf-text-sampler.ts` in bridge agent)
+- Uses a cascade: mupdf text extraction → OCR (tesseract.js) → AI vision fallback
+- The AI vision fallback is **configurable** via `AI_MODELS` + `PDF_EXTRACTION_CONFIG` in admin_config
+- `PDF_EXTRACTION_CONFIG.ai_vision_model_id` names the model ID from the `AI_MODELS` catalog to use
+- Supports Google Gemini and Anthropic providers
+- **Hard limit**: files larger than 100 MB are skipped (logged as warnings, surfaced in the PDF text sample progress UI)
+
+### ERP Product Category Classification
+- Uses Claude (via OpenRouter) to classify ERP items into product categories when deterministic MG code rules can't resolve them
+- Confidence < 65% → status `pending` (requires human review in the Review Queue)
+- Confidence ≥ 65% → status `auto_applied`
 
 ---
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -144,7 +144,7 @@ popdam3/
 │   │   ├── bulk-job-runner/      # Legacy bulk orchestrator (being replaced by worker)
 │   │   ├── _shared/              # Shared code for all edge functions
 │   │   │   ├── admin-handlers/   # Extracted handler modules for admin-api
-│   │   │   ├── http.ts           # CORS headers, json(), err() helpers
+│   │   │   ├── http.ts           # corsServe(), json(), err() — CORS + HTTP helpers
 │   │   │   ├── service-client.ts # Creates Supabase client with service role key
 │   │   │   ├── sku-parser.ts     # SKU → metadata extraction
 │   │   │   ├── style-grouping.ts # SKU folder detection + primary asset selection
@@ -272,6 +272,7 @@ There are **two separate edge functions** for different auth models. They must n
 - **Callers**: Bridge Agent, Windows Agent
 - **Key routes**: `register`, `heartbeat`, `ingest`, `batch-ingest`, `update`, `move`, `complete-job`, `pair`, `progress`, `report-hygiene`
 - The heartbeat response doubles as a **config sync channel** — agents receive scan roots, feature flags, and command signals via heartbeat responses
+- Config keys are **filtered by agent type**: bridge agents receive AI API keys and scan config; Windows agents receive NAS credentials and render settings. Neither agent type receives the other's secrets.
 
 ### `admin-api` (1,268 lines)
 - **Auth**: User JWT (Bearer token) + admin role check via `user_roles` table
@@ -413,7 +414,7 @@ Style groups inherit metadata from their assets: licensor, property, division, M
 
 ## 13. AI Tagging Pipeline
 
-Uses **Google Gemini** (via the Cloud Worker or edge functions) to analyze asset thumbnails and generate:
+Uses a **configurable AI model** (Google Gemini by default) to analyze asset thumbnails and generate:
 - Tags (e.g., "frozen", "elsa", "snowflake", "blue", "winter")
 - Character identification (matched to `characters` table)
 - Asset type classification (art_piece, product, packaging, tech_pack, photography)
@@ -421,6 +422,11 @@ Uses **Google Gemini** (via the Cloud Worker or edge functions) to analyze asset
 - Theme detection (big_theme, little_theme)
 - Cover description (one-sentence summary)
 - Licensed/unlicensed determination
+
+The model is selected from the `AI_MODELS` admin config array (first entry with `provider: "google"` and `"vision"` capability). Change the active model in Settings → Admin Config without redeploying. See `docs/MODEL_RULES.md` for details.
+
+### PDF text extraction
+Before tagging, the bridge agent optionally extracts text from PDFs via a cascade: mupdf → OCR → AI vision fallback. Results are stored in `pdf_text_samples` and injected into the tagging prompt as additional context. Files over 100 MB are skipped automatically (logged with reason).
 
 ### Tag propagation
 After tagging, a bulk operation copies AI tags from the primary tagged asset to all siblings in the same style group (excluding file-specific tags like "front view" or "packaging").


### PR DESCRIPTION
Updates three docs to match code that was changed in PRs #84–#88:

- **MODEL_RULES.md**: Fix incorrect `ai-tag` entry (was "Claude via Anthropic" — actually uses Google Gemini). Clarify configurability. Add PDF text extraction section.
- **ONBOARDING.md**: `http.ts` now exports `corsServe()`. Heartbeat config is filtered by agent type. AI tagging uses configurable model, not hardcoded Gemini. PDF extraction has 100 MB limit.
- **ARCHITECTURE.md**: `corsServe()` pattern for all new edge functions. Admin query `SELECT`-only restriction documented.

https://claude.ai/code/session_013ZJwCosLgmPAs5gLFwhwfp