### PR TITLE
fix(agent-api): reconcile and refresh before marking a crawl run completed (#108)

### DIFF
--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -2929,26 +2929,133 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
         updated_at: new Date().toISOString(),
       });
     } else {
-      await db.from("style_guide_crawl_runs").update({
+      // ── Reconcile BEFORE completion ───────────────────────────────
+      // shared-db migration 20260905104802 adds CHECK constraint
+      // `style_guide_crawl_runs_completion_requires_reconcile`: a run may not be
+      // written as status='completed' until BOTH reconcile_completed_at and
+      // refresh_completed_at are set. So the order here is mandatory:
+      //   1. run reconcile_stale_sg_files_batch to exhaustion (it is bounded and
+      //      resumable, so it must be called in a loop until done),
+      //   2. refresh the matviews WITH the run id (that is what stamps
+      //      refresh_completed_at),
+      //   3. only then mark the run completed.
+      // Both RPCs are service-role only; `db` is serviceClient(), so the caller
+      // key is correct.
+      let reconcileOk = accessibleRoots.length > 0;
+      let reconcileFailure: string | undefined = accessibleRoots.length > 0
+        ? undefined
+        : "No accessible roots to reconcile; refusing to report completion";
+
+      const MAX_RECONCILE_BATCHES = 500;
+
+      for (const root of accessibleRoots) {
+        const rootLabel = root.split("/").filter(Boolean).pop() || root;
+        let batches = 0;
+        for (;;) {
+          const { data, error: reconcileErr } = await db.rpc("reconcile_stale_sg_files_batch", {
+            p_root_label: rootLabel,
+            p_run_id: runId,
+            p_batch_size: 5000,
+            p_min_ratio: 0.5,
+          });
+          if (reconcileErr) {
+            reconcileOk = false;
+            reconcileFailure = `Reconcile failed for root "${rootLabel}": ${reconcileErr.message}`;
+            console.error("[complete-style-guide-crawl]", reconcileFailure);
+            break;
+          }
+          const batch = (Array.isArray(data) ? data[0] : data) as {
+            deactivated: number;
+            remaining: number;
+            done: boolean;
+            guard_state: string | null;
+            guard_reason: string | null;
+          } | null;
+          if (!batch) {
+            reconcileOk = false;
+            reconcileFailure = `Reconcile returned no result for root "${rootLabel}"`;
+            console.error("[complete-style-guide-crawl]", reconcileFailure);
+            break;
+          }
+          console.log(
+            `[complete-style-guide-crawl] Reconcile root "${rootLabel}": deactivated=${batch.deactivated} remaining=${batch.remaining} done=${batch.done}`,
+          );
+          if (batch.guard_state && batch.guard_state !== "ok") {
+            // The guard refused to inactivate anything and parked the run as
+            // attention_required. Do NOT mark it completed.
+            reconcileOk = false;
+            reconcileFailure =
+              `Reconcile guard "${batch.guard_state}" fired for root "${rootLabel}": ${batch.guard_reason ?? "no reason given"}`;
+            console.error("[complete-style-guide-crawl]", reconcileFailure);
+            break;
+          }
+          if (batch.done) break;
+          if (++batches >= MAX_RECONCILE_BATCHES) {
+            reconcileOk = false;
+            reconcileFailure =
+              `Reconcile did not finish for root "${rootLabel}" after ${MAX_RECONCILE_BATCHES} batches`;
+            console.error("[complete-style-guide-crawl]", reconcileFailure);
+            break;
+          }
+        }
+        if (!reconcileOk) break;
+      }
+
+      // Refresh the PopSG aggregation matviews now that is_active is finalized
+      // for this crawl — they back the guides grid + folder tree so the Library
+      // stops re-aggregating all active rows per request. Passing the run id is
+      // required: that is what stamps refresh_completed_at, without which the
+      // completion CHECK constraint rejects the update below.
+      if (reconcileOk) {
+        const { error: refreshErr } = await db.rpc("refresh_style_guide_matviews", {
+          p_run_id: runId,
+          p_search_batch_size: 5000,
+        });
+        if (refreshErr) {
+          reconcileOk = false;
+          reconcileFailure = `Matview refresh failed: ${refreshErr.message}`;
+          console.error("[complete-style-guide-crawl]", reconcileFailure);
+        }
+      }
+
+      if (!reconcileOk) {
+        // Completion was not earned. Record the run as failed with the reason
+        // rather than attempting a write the database would reject anyway.
+        await db.from("style_guide_crawl_runs").update({
+          status: "failed",
+          error_message: reconcileFailure,
+          completed_at: new Date().toISOString(),
+          files_found: finalFileCount,
+          ...(inaccessibleRoots.length ? { inaccessible_roots: inaccessibleRoots } : {}),
+        }).eq("id", runId);
+
+        await db.from("admin_config").upsert({
+          key: "STYLE_GUIDE_CRAWL_REQUEST",
+          value: {
+            status: "failed",
+            error: reconcileFailure,
+            completed_at: new Date().toISOString(),
+            files_found: finalFileCount,
+            inaccessible_roots: inaccessibleRoots,
+          },
+          updated_at: new Date().toISOString(),
+        });
+
+        console.log(
+          `[complete-style-guide-crawl] Run ${runId} done=${done}, files=${finalFileCount}, error=${reconcileFailure}`,
+        );
+        return json({ ok: true });
+      }
+
+      const { error: completeErr } = await db.from("style_guide_crawl_runs").update({
         status: "completed",
         completed_at: new Date().toISOString(),
         files_found: finalFileCount,
         ...(inaccessibleRoots.length ? { inaccessible_roots: inaccessibleRoots } : {}),
       }).eq("id", runId);
-
-      // Mark stale files via DB function (RPC is reliable; PostgREST PATCH with .neq()
-      // on UUID columns fails silently and leaves ghost rows active).
-      if (accessibleRoots.length > 0) {
-        for (const root of accessibleRoots) {
-          const rootLabel = root.split("/").filter(Boolean).pop() || root;
-          const { data: deactivated, error: deactivateErr } = await db
-            .rpc("deactivate_stale_sg_files", { p_root_label: rootLabel, p_run_id: runId });
-          if (deactivateErr) {
-            console.error("[complete-style-guide-crawl] Staleness cleanup failed:", deactivateErr.message);
-          } else {
-            console.log(`[complete-style-guide-crawl] Deactivated ${deactivated} stale files for root "${rootLabel}"`);
-          }
-        }
+      if (completeErr) {
+        console.error("[complete-style-guide-crawl] Completion update failed:", completeErr.message);
+        return err(`Crawl completion failed: ${completeErr.message}`, 500);
       }
 
       await db.from("admin_config").upsert({
@@ -2961,16 +3068,6 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
         },
         updated_at: new Date().toISOString(),
       });
-
-      // Refresh the PopSG aggregation matviews now that is_active is finalized
-      // for this crawl — they back the guides grid + folder tree so the Library
-      // stops re-aggregating all active rows per request. Best-effort: a briefly
-      // stale matview is preferable to failing crawl completion.
-      // See migration popsg_aggregation_matviews.
-      const { error: refreshErr } = await db.rpc("refresh_style_guide_matviews");
-      if (refreshErr) {
-        console.error("[complete-style-guide-crawl] Matview refresh failed:", refreshErr.message);
-      }
     }
     console.log(
       `[complete-style-guide-crawl] Run ${runId} done=${done}, files=${finalFileCount}, error=${effectiveCrawlError || "none"}`,

--- a/supabase/functions/agent-api/index.ts
+++ b/supabase/functions/agent-api/index.ts
@@ -2942,9 +2942,7 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
       // Both RPCs are service-role only; `db` is serviceClient(), so the caller
       // key is correct.
       let reconcileOk = accessibleRoots.length > 0;
-      let reconcileFailure: string | undefined = accessibleRoots.length > 0
-        ? undefined
-        : "No accessible roots to reconcile; refusing to report completion";
+      let reconcileFailure: string | undefined = accessibleRoots.length > 0 ? undefined : "No accessible roots to reconcile; refusing to report completion";
 
       const MAX_RECONCILE_BATCHES = 500;
 
@@ -2984,16 +2982,14 @@ async function handleCompleteStyleGuideCrawl(body: Record<string, unknown>) {
             // The guard refused to inactivate anything and parked the run as
             // attention_required. Do NOT mark it completed.
             reconcileOk = false;
-            reconcileFailure =
-              `Reconcile guard "${batch.guard_state}" fired for root "${rootLabel}": ${batch.guard_reason ?? "no reason given"}`;
+            reconcileFailure = `Reconcile guard "${batch.guard_state}" fired for root "${rootLabel}": ${batch.guard_reason ?? "no reason given"}`;
             console.error("[complete-style-guide-crawl]", reconcileFailure);
             break;
           }
           if (batch.done) break;
           if (++batches >= MAX_RECONCILE_BATCHES) {
             reconcileOk = false;
-            reconcileFailure =
-              `Reconcile did not finish for root "${rootLabel}" after ${MAX_RECONCILE_BATCHES} batches`;
+            reconcileFailure = `Reconcile did not finish for root "${rootLabel}" after ${MAX_RECONCILE_BATCHES} batches`;
             console.error("[complete-style-guide-crawl]", reconcileFailure);
             break;
           }


### PR DESCRIPTION
Closes #108. Unblocks the production apply of shared-db migration `20260905104802` (shared-db PR #2339, merge `9e83aa0460517613b44fd4bdf553b55f299b19ae`).

### Half 1 — completion ordering

The migration adds CHECK constraint `style_guide_crawl_runs_completion_requires_reconcile`, which rejects any write of `status='completed'` unless both `reconcile_completed_at` and `refresh_completed_at` are set. `complete-style-guide-crawl` wrote the completed status *first* and reconciled afterwards, so every crawl run would have failed at completion the moment the migration was applied.

The completion path in `supabase/functions/agent-api/index.ts` now, in order:

1. Loops the new bounded, resumable `public.reconcile_stale_sg_files_batch` per accessible root until it reports `done`, replacing the single unbounded `deactivate_stale_sg_files` call. A batch cap stops a pathological root looping forever.
2. Honours the reconciliation guard. When `guard_state` is anything but `ok`, the database has parked the run as `attention_required` and inactivated nothing, so the run is recorded as failed with the guard reason rather than reported complete.
3. Calls `refresh_style_guide_matviews` **with `p_run_id`** — that argument is what stamps `refresh_completed_at`. The old no-argument call still resolves (every parameter defaults) but would leave that column null and the completion write would be rejected.
4. Only then writes `status='completed'`, and now checks that write for an error instead of discarding it.

### Half 2 — the caller key

Answered: this handler's client is `serviceClient()`, which uses `SUPABASE_SERVICE_ROLE_KEY`. The migration's revoke of EXECUTE from the `authenticated` role does not affect it, and no key change is needed.

On the transaction concern: `REFRESH MATERIALIZED VIEW CONCURRENTLY` is permitted inside a transaction block (unlike `CREATE INDEX CONCURRENTLY` or `VACUUM`), and the migration itself runs it inside a plpgsql function, which is always in one. The PostgREST-wrapped RPC call therefore needs no change.

### Second copy

`supabase-popsg/supabase/functions/agent-api/index.ts` is deliberately left untouched. `AGENTS.md`, `docs/POPSG.md`, `docs/architecture.md` and `docs/KNOWN_QUIRKS.md` all record that directory as dead code that is never deployed, and `deploy-popsg-supabase.yml` intentionally fails.

### Verification

`deno check supabase/functions/agent-api/index.ts` reports the same single pre-existing `TS2345` at line 822 (`assignStyleGroup`) on this branch as on `origin/main`, and no new errors. Nothing was deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)