### PR TITLE
fix(worker): stop the nightly style-group rebuild dying on a progress count

### DIFF
--- a/apps/worker/src/handlers/style-groups.test.ts
+++ b/apps/worker/src/handlers/style-groups.test.ts
@@ -9,3 +9,17 @@ test("database errors retain a timeout code when PostgREST supplies a blank mess
 test("completely blank database errors get a useful message", () => {
   assert.equal(formatError({ message: "", code: "", details: "", hint: "" }), "Database error supplied no message");
 });
+
+test("a blank HEAD-style error still names the HTTP status", () => {
+  assert.equal(
+    formatError({ message: "", code: "", details: "", hint: "" }, { status: 500, statusText: "Internal Server Error" }),
+    "Database error supplied no message | http_status=500 | http_status_text=Internal Server Error",
+  );
+});
+
+test("a populated error keeps its message and gains the HTTP status", () => {
+  assert.equal(
+    formatError({ message: "canceling statement due to statement timeout", code: "57014" }, { status: 500, statusText: "Internal Server Error" }),
+    "canceling statement due to statement timeout | code=57014 | http_status=500 | http_status_text=Internal Server Error",
+  );
+});

--- a/apps/worker/src/handlers/style-groups.ts
+++ b/apps/worker/src/handlers/style-groups.ts
@@ -41,7 +41,12 @@ type RebuildState = {
   finalize_cursor?: number;
 };
 
-export function formatError(e: unknown): string {
+export function formatError(e: unknown, http?: { status?: number | null; statusText?: string | null }): string {
+  const httpParts = [
+    http?.status ? `http_status=${String(http.status)}` : null,
+    http?.statusText ? `http_status_text=${String(http.statusText)}` : null,
+  ].filter(Boolean) as string[];
+
   if (e && typeof e === "object") {
     const err = e as { message?: unknown; code?: unknown; details?: unknown; hint?: unknown };
     const parts = [
@@ -49,12 +54,48 @@ export function formatError(e: unknown): string {
       err.code ? `code=${String(err.code)}` : null,
       err.details ? `details=${String(err.details)}` : null,
       err.hint ? `hint=${String(err.hint)}` : null,
-    ].filter(Boolean);
-    if (parts.length > 0) return parts.join(" | ");
-    return "Database error supplied no message";
+    ].filter(Boolean) as string[];
+    if (parts.length > 0) return [...parts, ...httpParts].join(" | ");
+    // PostgREST returns no body on a HEAD request, so every field can be blank.
+    // The HTTP status is then the only thing that says what went wrong.
+    return [
+      "Database error supplied no message",
+      ...httpParts,
+    ].join(" | ");
   }
   const fallback = String(e ?? "").trim();
-  return fallback || "Database error supplied no message";
+  if (fallback) return [fallback, ...httpParts].join(" | ");
+  return ["Database error supplied no message", ...httpParts].join(" | ");
+}
+
+/**
+ * Row count for progress reporting only.
+ *
+ * Uses PostgREST's "planned" count (the planner's row estimate) rather than an
+ * exact count: exact counting `assets where is_deleted = false` scans ~135k
+ * index entries with ~69k heap fetches, which measured 1.1 s warm and 14.9 s
+ * cold against the 8 s statement_timeout inherited from `authenticator`. On
+ * 2026-09-06 that killed the whole nightly rebuild before it processed a single
+ * asset.
+ *
+ * `head` is deliberately false: a HEAD response carries no body, so a PostgREST
+ * error arrives with every field blank and the failure cannot describe itself.
+ */
+async function countRowsForProgress(
+  table: "assets" | "style_groups",
+  applyFilters: boolean,
+): Promise<{ count: number | null; error: string | null }> {
+  const client = db();
+  let q = client.from(table).select("id", { count: "planned", head: false }).limit(0);
+  if (applyFilters) q = q.eq("is_deleted", false);
+  const res = await q;
+  if (res.error) {
+    return {
+      count: null,
+      error: formatError(res.error, { status: res.status, statusText: res.statusText }),
+    };
+  }
+  return { count: res.count ?? null, error: null };
 }
 
 function isStatementTimeout(msg: string): boolean {
@@ -155,23 +196,15 @@ export async function handleRebuildStyleGroups(opState: OpState): Promise<BatchR
 
   state = normalizeState(state);
 
-  // Count total assets once
+  // Count total assets once. Progress reporting only - never fatal.
   if (typeof state.total_assets !== "number") {
-    const { count, error: countErr } = await client
-      .from("assets")
-      .select("id", { count: "exact", head: true })
-      .eq("is_deleted", false);
+    const { count, error: countErr } = await countRowsForProgress("assets", true);
     if (countErr) {
-      return {
-        ok: false,
-        done: false,
-        error: formatBatchError({
-          rpc: "assets_exact_count",
-          stage: "clear_assets",
-          rawError: formatError(countErr),
-        }),
-        error_stage: "clear_assets",
-      };
+      logger.warn("rebuild-style-groups: asset count unavailable, continuing without a progress total", {
+        query: "assets_planned_count",
+        stage: "clear_assets",
+        error: countErr,
+      });
     }
     state.total_assets = count ?? 0;
     await saveState(state);
@@ -253,7 +286,14 @@ export async function handleRebuildStyleGroups(opState: OpState): Promise<BatchR
 
     let totalGroupsBeforeDelete: number | undefined;
     if (!hasMore) {
-      const { count } = await client.from("style_groups").select("id", { count: "exact", head: true });
+      const { count, error: sgCountErr } = await countRowsForProgress("style_groups", false);
+      if (sgCountErr) {
+        logger.warn("rebuild-style-groups: style group count unavailable", {
+          query: "style_groups_planned_count",
+          stage: "clear_assets",
+          error: sgCountErr,
+        });
+      }
       totalGroupsBeforeDelete = count ?? undefined;
     }
 


### PR DESCRIPTION
Diagnosis and fix for u2giants/shared-db#2439.

## What actually failed

`assets_exact_count` is not an RPC — it is the label the worker puts on PostgREST's exact count of `assets where is_deleted = false`, taken once at the top of `clear_assets` purely to show a progress total.

Measured on production today:

| | |
|---|---|
| Plan | Index Only Scan on `idx_assets_pdf_not_deleted`, 135,251 rows, **69,032 heap fetches** |
| Cold execution | **14,900 ms** |
| Warm execution | 1,102 ms |
| `authenticator` `statement_timeout` | **8s** (`service_role` has no override, so it inherits it) |

The 06:00 UTC nightly run hits a cold buffer cache, the count blows past 8 s, and the whole rebuild aborts having processed nothing. `started_at` 06:00:01.739Z → `updated_at` 06:00:09.953Z matches the timeout exactly.

## Why the error was empty

The count was sent as an HTTP **HEAD** request. A HEAD response carries no body, so PostgREST's error reached supabase-js with `message`, `code`, `details` and `hint` all blank — and `formatError` correctly reported that it had nothing to report.

## The change

- The count uses PostgREST's `planned` count (planner estimate — 135,115 against an actual 135,251) instead of an exact scan, and **a count failure is no longer fatal**: it logs a warning and the rebuild continues. A number used only for a progress bar must not be able to cancel the night's work.
- `head: false` with `limit(0)` so an error body survives, and `formatError` now appends `http_status` / `http_status_text`, so even a blank-bodied error says what happened.
- The `style_groups` count on the same path had the identical HEAD trap and is converted with it.

## Verification

- `tsc --noEmit` clean.
- Full worker suite: **133 passing, 0 failing**, including two new cases covering the blank-bodied error.
- No production write was made. All measurements were taken as `supabase_read_only_user`.

Live confirmation of the fix is the next nightly (or a manual trigger) leaving `admin_config.BULK_OPERATIONS -> 'rebuild-style-groups'` in a successful terminal status with a nonzero `total_processed`.

Unblocks u2giants/shared-db#2440, which cannot chain to a completion signal that never arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)