### PR TITLE
Record and alert terminal style-group rebuild outcomes

### DIFF
--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -55,4 +55,8 @@ export const config = {
 
   // Assets fetched per AI tagging batch
   aiBatchSize: optionalInt("AI_BATCH_SIZE", 50),
+
+  // Owner-selected operational destination for terminal bulk-operation failures.
+  // Empty is intentional until an existing monitored destination is supplied.
+  bulkOperationAlertWebhookUrl: optional("BULK_OPERATION_ALERT_WEBHOOK_URL", ""),
 } as const;

--- a/apps/worker/src/operation-loop.ts
+++ b/apps/worker/src/operation-loop.ts
@@ -30,6 +30,7 @@ import { maybeMirrorSeaDrive } from "./handlers/seadrive-mirror.js";
 import { handleEmbedSearch } from "./handlers/embed-search.js";
 import { handleReprocessMetadata } from "./handlers/metadata-reprocess.js";
 import { withDependencyTimeout } from "./bounded-dependency.js";
+import { alertTerminalFailure, appendTerminalRun, type TerminalRun } from "./terminal-outcomes.js";
 import {
   getNextAutoResumeAt,
   isTransientInterruption,
@@ -47,6 +48,27 @@ const submissionLeaseRetryAfter = new Map<string, number>();
  *  worker has no timeout, so 50 keeps ops running hot while still yielding often
  *  enough to check for user interruptions and serve other lanes. */
 const MAX_BATCHES_PER_TICK = 50;
+
+async function recordStyleGroupTerminalOutcome(
+  opKey: string,
+  state: OpState,
+  status: "succeeded" | "failed",
+): Promise<void> {
+  if (opKey !== "rebuild-style-groups" || !state.run_id || !state.started_at) return;
+  const run: TerminalRun = {
+    operation: opKey,
+    run_id: state.run_id,
+    status,
+    stage: state.last_stage,
+    error: state.error,
+    reason_code: state.interruption_reason_code,
+    progress: state.progress ?? {},
+    started_at: state.started_at,
+    ended_at: state.updated_at ?? new Date().toISOString(),
+  };
+  await appendTerminalRun(db(), run);
+  await alertTerminalFailure(run);
+}
 
 // Lane isolation — operations in the same lane are mutually exclusive
 const OP_LANES: Record<string, string> = {
@@ -642,15 +664,18 @@ export async function tick(): Promise<void> {
 
   const [opKey, opState] = runningEntries[0] as [string, OpState];
 
-  // Legacy op: no cursor — mark interrupted
+  // Legacy op: no cursor — it cannot be resumed safely.
   if (opState.cursor === undefined) {
-    await persistOpState(opKey, {
+    const failedState: OpState = {
       ...opState,
-      status: "interrupted",
+      run_id: opState.run_id ?? crypto.randomUUID(),
+      status: "failed",
       interruption_reason_code: "legacy_format",
+      error: "Operation state has no cursor and cannot be resumed safely",
       updated_at: new Date().toISOString(),
-    });
-    logger.warn("tick: legacy op interrupted", { opKey });
+    };
+    if (await persistOpState(opKey, failedState)) await recordStyleGroupTerminalOutcome(opKey, failedState, "failed");
+    logger.warn("tick: legacy op failed", { opKey });
     return;
   }
 
@@ -699,11 +724,11 @@ export async function tick(): Promise<void> {
       const errMsg = normalizeBatchError(e, "Dispatch failed without an error message");
       const reason = classifyError(errMsg);
       logger.error("tick: dispatch threw", { opKey, error: errMsg });
-      await persistOpState(opKey, {
+      const failureState: OpState = {
         ...currentState,
         cursor,
         progress,
-        status: "interrupted",
+        status: isTransientInterruption(reason) ? "interrupted" : "failed",
         interruption_reason_code: reason,
         error: errMsg,
         last_stage: currentState.last_stage,
@@ -711,7 +736,9 @@ export async function tick(): Promise<void> {
         last_successful_cursor: cursor,
         next_auto_resume_at: nextAutoResumeAt(reason, currentState),
         updated_at: new Date().toISOString(),
-      });
+      };
+      const persisted = await persistOpState(opKey, failureState);
+      if (persisted && failureState.status === "failed") await recordStyleGroupTerminalOutcome(opKey, failureState, "failed");
       return;
     }
 
@@ -833,15 +860,16 @@ export async function tick(): Promise<void> {
     const killReason = detectFailureKillSwitch(progress, currentState.started_at);
     if (killReason) {
       logger.error("tick: failure kill switch triggered", { opKey, reason: killReason, batchCount });
-      await persistOpState(opKey, {
+      const failureState: OpState = {
         ...currentState,
         cursor,
         progress,
-        status: "interrupted",
+        status: "failed",
         interruption_reason_code: "repeated_failure",
         error: `Auto-stopped: ${killReason}`,
         updated_at: new Date().toISOString(),
-      });
+      };
+      if (await persistOpState(opKey, failureState)) await recordStyleGroupTerminalOutcome(opKey, failureState, "failed");
       return;
     }
 
@@ -860,11 +888,11 @@ export async function tick(): Promise<void> {
         elapsed_ms: result.elapsed_ms,
         postgres_code: result.postgres_code,
       });
-      await persistOpState(opKey, {
+      const failureState: OpState = {
         ...currentState,
         cursor,
         progress,
-        status: "interrupted",
+        status: isTransientInterruption(reason) ? "interrupted" : "failed",
         interruption_reason_code: reason,
         error: batchErr,
         last_stage: result.error_stage,
@@ -873,7 +901,9 @@ export async function tick(): Promise<void> {
         retry_page_size: result.retry_page_size ?? currentState.retry_page_size,
         next_auto_resume_at: nextAutoResumeAt(reason, currentState),
         updated_at: new Date().toISOString(),
-      });
+      };
+      const persisted = await persistOpState(opKey, failureState);
+      if (persisted && failureState.status === "failed") await recordStyleGroupTerminalOutcome(opKey, failureState, "failed");
       return;
     }
 
@@ -924,7 +954,7 @@ export async function tick(): Promise<void> {
 
     if (result.done) {
       logger.info("tick: op completed", { opKey, batches: batchCount, progress });
-      await persistOpState(opKey, {
+      const completedState: OpState = {
         ...currentState,
         cursor,
         progress,
@@ -938,7 +968,8 @@ export async function tick(): Promise<void> {
         last_successful_cursor: cursor,
         result_message: buildResultMessage(opKey, progress),
         updated_at: new Date().toISOString(),
-      });
+      };
+      if (await persistOpState(opKey, completedState)) await recordStyleGroupTerminalOutcome(opKey, completedState, "succeeded");
       return;
     }
 

--- a/apps/worker/src/terminal-outcomes.test.ts
+++ b/apps/worker/src/terminal-outcomes.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { alertTerminalFailure, appendTerminalRun, type TerminalRun, type TerminalRunStore } from "./terminal-outcomes.js";
+
+const failedRun: TerminalRun = {
+  operation: "rebuild-style-groups",
+  run_id: "failed-run-1",
+  status: "failed",
+  stage: "clear_assets",
+  error: "Deliberate failure",
+  reason_code: "deliberate_test",
+  progress: { total_processed: 0 },
+  started_at: "2026-09-09T06:00:00.000Z",
+  ended_at: "2026-09-09T06:00:01.000Z",
+};
+
+test("a later success does not overwrite a recorded failed run", async () => {
+  const rows: TerminalRun[] = [];
+  const store: TerminalRunStore = {
+    from: () => ({
+      insert: async (row) => {
+        if (rows.some((existing) => existing.operation === row.operation && existing.run_id === row.run_id)) {
+          return { error: { code: "23505", message: "duplicate key" } };
+        }
+        rows.push(row);
+        return { error: null };
+      },
+    }),
+  };
+
+  assert.equal(await appendTerminalRun(store, failedRun), true);
+  assert.equal(await appendTerminalRun(store, { ...failedRun, run_id: "successful-run-2", status: "succeeded", error: undefined, reason_code: undefined }), true);
+  assert.deepEqual(rows.map((row) => [row.run_id, row.status]), [["failed-run-1", "failed"], ["successful-run-2", "succeeded"]]);
+});
+
+test("retrying the same terminal run is idempotent", async () => {
+  const store: TerminalRunStore = {
+    from: () => ({ insert: async () => ({ error: { code: "23505", message: "duplicate key" } }) }),
+  };
+  assert.equal(await appendTerminalRun(store, failedRun), true);
+});
+
+test("a failed terminal outcome posts a deliberate failure signal to the configured destination", async () => {
+  let request: Request | undefined;
+  const delivery = await alertTerminalFailure(
+    failedRun,
+    async (input, init) => {
+      request = new Request(input, init);
+      return new Response(null, { status: 202 });
+    },
+    "https://alerts.example.test/nightly",
+  );
+  assert.equal(delivery, "delivered");
+  assert.equal(request?.method, "POST");
+  assert.deepEqual(await request?.json(), { type: "bulk_operation_failed", ...failedRun });
+});
+
+test("a missing owner-selected destination is a visible non-delivery", async () => {
+  assert.equal(await alertTerminalFailure(failedRun, fetch, ""), "destination_unconfigured");
+});

--- a/apps/worker/src/terminal-outcomes.ts
+++ b/apps/worker/src/terminal-outcomes.ts
@@ -1,0 +1,80 @@
+/**
+ * Durable terminal-outcome recording for bulk operations.
+ *
+ * The live BULK_OPERATIONS JSON is intentionally mutable.  This writer is only
+ * for the append-only history table introduced by shared-db #2447, so a later
+ * successful run can never erase an earlier failed run.
+ */
+
+import { config } from "./config.js";
+import { logger } from "./logger.js";
+
+export type TerminalRunStatus = "succeeded" | "failed";
+
+export interface TerminalRun {
+  operation: string;
+  run_id: string;
+  status: TerminalRunStatus;
+  stage?: string;
+  error?: string;
+  reason_code?: string;
+  progress: Record<string, unknown>;
+  started_at: string;
+  ended_at: string;
+}
+
+export interface TerminalRunStore {
+  from(table: "bulk_operation_runs"): {
+    insert(row: TerminalRun): PromiseLike<{ error: { code?: string; message: string } | null }>;
+  };
+}
+
+export type AlertDelivery = "delivered" | "destination_unconfigured" | "delivery_failed";
+
+export async function appendTerminalRun(store: TerminalRunStore, run: TerminalRun): Promise<boolean> {
+  const { error } = await store.from("bulk_operation_runs").insert(run);
+  if (!error || error.code === "23505") return true; // Safe retry of the same run.
+  logger.error("bulk operation history append failed", {
+    operation: run.operation,
+    run_id: run.run_id,
+    error: error.message,
+  });
+  return false;
+}
+
+export async function alertTerminalFailure(
+  run: TerminalRun,
+  fetchImpl: typeof fetch = fetch,
+  destination = config.bulkOperationAlertWebhookUrl,
+): Promise<AlertDelivery> {
+  if (run.status !== "failed") return "delivered";
+  if (!destination) {
+    // Deliberately loud: deployment must not create a silent alert channel.
+    logger.error("bulk operation failure alert was not delivered: BULK_OPERATION_ALERT_WEBHOOK_URL is unset", {
+      operation: run.operation,
+      run_id: run.run_id,
+    });
+    return "destination_unconfigured";
+  }
+
+  try {
+    const response = await fetchImpl(destination, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "bulk_operation_failed", ...run }),
+    });
+    if (response.ok) return "delivered";
+    logger.error("bulk operation failure alert delivery failed", {
+      operation: run.operation,
+      run_id: run.run_id,
+      http_status: response.status,
+    });
+  } catch (error) {
+    logger.error("bulk operation failure alert delivery failed", {
+      operation: run.operation,
+      run_id: run.run_id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return "delivery_failed";
+}

--- a/docs/BULK_JOBS.md
+++ b/docs/BULK_JOBS.md
@@ -139,6 +139,20 @@ submit only when the returned envelope includes `lease_receipt_issued = true`
 and a non-empty receipt. A restart reloads the saved provider batch ID and checks
 that same job; it never treats a generic `ok` response as permission to submit.
 
+### Rebuild outcome history and alerts
+
+After a `rebuild-style-groups` run reaches a non-retryable failure or completes, the
+worker appends one immutable row to `public.bulk_operation_runs`. A later success has a
+new `run_id` and cannot overwrite the earlier failure. Transient interruptions remain
+resumable and are not terminal history rows.
+
+Failed terminal outcomes POST a safe operational payload (operation, run identifier,
+stage, error, reason, counters, and timestamps) to the Railway-only
+`BULK_OPERATION_ALERT_WEBHOOK_URL`. This must be an owner-selected existing monitored
+destination. When it is unset or rejects delivery, the worker logs an error rather than
+claiming an alert was sent. Cron remains an enqueue-only signal and is never used to
+decide whether the rebuild succeeded.
+
 OpenRouter phases are `prepared`, `submitting`, `pending`, `applying`,
 `completed`, and `ambiguous_submission`. Pending jobs are checked no faster than
 every 10 seconds. An expired submission lease without a saved provider ID is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,7 @@ Runs on Railway. Environment variables are set in the Railway project dashboard.
 | `OPENROUTER_API_KEY` | Yes | AI tagging and ERP classification — **not the same as admin_config.OPENROUTER_API_KEY** |
 | `META_API_KEY` | No | Meta Model API direct access when Image Tagging selects `meta-direct/muse-spark-1.3-contributor` |
 | `GOOGLE_AI_API_KEY` | No | Legacy fallback if no OpenRouter key |
+| `BULK_OPERATION_ALERT_WEBHOOK_URL` | No until owner selects an existing monitored destination | Receives terminal `rebuild-style-groups` failure alerts; an unset value is logged as an undelivered alert, never treated as success |
 
 **Critical:** `OPENROUTER_API_KEY` in Railway and `OPENROUTER_API_KEY` in `admin_config` are two separate things. Setting the key in the admin UI (Settings → AI Models) only updates `admin_config`. The Railway worker reads exclusively from Railway ENV variables.
 


### PR DESCRIPTION
Closes #117.\n\nImplements the PopDAM half of shared-db #2439:\n\n- appends one immutable completed or non-retryable failed ebuild-style-groups row keyed by run ID; a later success cannot overwrite a failure\n- turns non-retryable worker errors into terminal failed states while transient interruptions remain resumable\n- sends a structured terminal-failure payload to BULK_OPERATION_ALERT_WEBHOOK_URL; if the owner-selected destination is absent or rejects delivery, the worker logs an explicit undelivered alert\n- documents the Railway setting and adds tests for retention, idempotence, signal payload, and missing-destination visibility\n\nVerification: 
pm run build; worker test suite: 151 passing.\n\nDo not merge or deploy yet. Shared-db #2447 must first be applied and catalog-verified in production. Live acceptance still requires an owner-selected existing monitored alert destination, then a deliberate failed rebuild alert while cron job 7 remains succeeded, followed by a separate successful run.