### PR TITLE
Phase 4: add PopDAM task gates

### DIFF
--- a/.ai-devops/task-gates.json
+++ b/.ai-devops/task-gates.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "_comment": "PopDAM strengthens browser, agent, worker, function, release, and shared-database paths while preserving its multi-runtime production contracts.",
+  "paths": [
+    { "glob": "AGENTS.md", "class": "reviewer-safety" },
+    { "glob": "HANDOFF.md", "class": "reviewer-safety" },
+    { "glob": "HANDOFF.d/**", "class": "reviewer-safety" },
+    { "glob": "plan_*.md", "class": "reviewer-safety" },
+    { "glob": ".ai-devops/**", "class": "reviewer-safety" },
+    { "glob": "scripts/test-task-gates.sh", "class": "reviewer-safety" },
+    { "glob": "src/**", "class": "ui-live-workflow" },
+    { "glob": ".github/workflows/**", "class": "deployment" },
+    { "glob": "Dockerfile*", "class": "deployment" },
+    { "glob": "nginx.conf", "class": "deployment" },
+    { "glob": "deploy/**", "class": "deployment" },
+    { "glob": "apps/worker/**", "class": "deployment" },
+    { "glob": "apps/bridge-agent/**", "class": "deployment" },
+    { "glob": "apps/windows-agent/**", "class": "deployment" },
+    { "glob": "apps/popdam-helper/**", "class": "deployment" },
+    { "glob": "packages/path-filters/**", "class": "deployment" },
+    { "glob": "supabase/functions/**", "class": "deployment" },
+    { "glob": "package.json", "class": "deployment" },
+    { "glob": "shared-db/**", "class": "shared-db" },
+    { "glob": "supabase/migrations/**", "class": "shared-db" },
+    { "glob": "src/integrations/supabase/types.ts", "class": "shared-db" },
+    { "glob": "fixtures/task-gates/governed-data/**", "class": "shared-db" }
+  ],
+  "gates": {
+    "prose": { "required": ["direct-main-reconciliation"], "forbidden_actions": [] },
+    "code": { "required": ["direct-main-reconciliation", "local-tests"], "forbidden_actions": [] },
+    "ui-live-workflow": { "required": ["direct-main-reconciliation", "local-tests", "authenticated-workflow-proof", "visual-proof", "repository-rulebook-full-treatment"], "forbidden_actions": [] },
+    "reviewer-safety": { "required": ["direct-main-reconciliation", "local-tests", "repository-rulebook-full-treatment"], "forbidden_actions": [] },
+    "deployment": { "required": ["direct-main-reconciliation", "local-tests", "production-release-review", "owner-authorization"], "forbidden_actions": [] },
+    "shared-db": { "required": ["stop-and-route-to-u2giants-shared-db", "governed-shared-db-branch-and-pr", "no-app-owned-schema"], "forbidden_actions": ["database"] }
+  }
+}

--- a/.github/workflows/task-gates.yml
+++ b/.github/workflows/task-gates.yml
@@ -1,0 +1,36 @@
+name: Task Gates
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+concurrency:
+  group: task-gates-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out PopDAM
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check out accepted task-gate engine
+        uses: actions/checkout@v4
+        with:
+          repository: popcre/ai-devops
+          ref: 4d83f9a5dc400f87408663eddac872b9074c18ed
+          path: .task-gates-toolkit
+          persist-credentials: false
+      - name: Add task-gate commands to the runner path
+        shell: bash
+        run: echo "$GITHUB_WORKSPACE/.task-gates-toolkit/bin" >> "$GITHUB_PATH"
+      - name: Verify installed command and PopDAM policy
+        shell: bash
+        run: |
+          ai-task-gates version
+          ai-repo-policy | jq -e '.repository == "u2giants/popdam3"'
+          bash scripts/test-task-gates.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,11 @@ Then load additional docs only when relevant — do **not** ingest every `.md` f
 
 ## Shared DB Gatekeeper
 
+Repository-local task routing is declared in `.ai-devops/task-gates.json` and
+verified by `scripts/test-task-gates.sh`. Protected browser, agent, worker,
+deployment, and shared-database paths require their full treatment;
+acknowledgement never bypasses a database-route refusal.
+
 This repo shares Supabase backend project `qsllyeztdwjgirsysgai` with the other
 POP apps. All database/schema changes for that shared backend must be authored
 in the canonical repo [`u2giants/shared-db`](https://github.com/u2giants/shared-db)

--- a/docs/verification/phase-4-task-gates-rollout.md
+++ b/docs/verification/phase-4-task-gates-rollout.md
@@ -1,0 +1,18 @@
+# Phase 4 task-gate rollout evidence
+
+Issue `popcre/ai-devops#335` adds repository-local routing policy and executable refusal evidence. The policy protects PopDAM browser, worker, agent, edge-function, release, and shared-database paths without changing application, database, runtime, host, or deployment behavior.
+
+## Required evidence
+
+- `bash scripts/test-task-gates.sh`: 16 passed / 0 failed. It verifies representative classifications, normal code shipping, database escalation refusal, failed acknowledgement and owner-request bypasses, and byte-exact rollback restoration.
+- `.github/workflows/task-gates.yml` repeats that proof on pull requests and `main` using the public accepted task-gate engine pinned by commit.
+- Existing shared-database guards remain independent and unchanged.
+- `npm run lint -- --quiet`: passed with zero findings.
+- `npm run build`: passed; 2,839 modules transformed.
+- The full Windows run passed 313/315 tests. One existing registry assertion compares LF text against the CRLF checkout, and one export test exceeded its five-second parallel-run timeout; that export file passed 5/5 alone in 1.06 seconds with a 15-second ceiling. GitHub CI remains the clean Linux application proof.
+
+The engine chooses the strongest matching class. Browser paths retain authenticated visual proof and full rulebook treatment. This rollout changes no browser, worker, agent, or function source path, so their runtime proofs are not required for this candidate.
+
+## Release boundary
+
+Railway rebuilds the production worker after every push to `main`, regardless of path. This rollout does not authorize production deployment, so its reviewed pull request must remain unmerged until that release is explicitly authorized. No database, runtime, host, infrastructure, or production action is part of this change.

--- a/scripts/test-task-gates.sh
+++ b/scripts/test-task-gates.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT; cd "$ROOT"; export AI_TASK_GATES_DIR="$TMP/state"; failures=0; passes=0
+pass(){ passes=$((passes + 1)); printf 'PASS: %s\n' "$1"; }; fail(){ printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+expect_class(){ local path="$1" expected="$2" label="$3" actual; printf '%s\n' "$path" > "$TMP/paths"; actual="$(ai-task-gates explain --json --paths-from "$TMP/paths" | jq -r '.observed_class')"; if [ "$actual" = "$expected" ]; then pass "$label"; else fail "$label (expected $expected, got $actual)"; fi; }
+expect_class README.md prose 'ordinary documentation uses the prose fast path'
+expect_class src/App.tsx ui-live-workflow 'browser behavior requires authenticated visual proof'
+expect_class AGENTS.md reviewer-safety 'agent rulebook receives protected full treatment'
+expect_class .ai-devops/task-gates.json reviewer-safety 'task-gate policy protects itself'
+expect_class .github/workflows/publish-frontend.yml deployment 'release workflow is protected deployment work'
+expect_class apps/worker/src/index.ts deployment 'Railway worker is protected deployment work'
+expect_class apps/bridge-agent/src/index.ts deployment 'NAS agent is protected deployment work'
+expect_class supabase/functions/admin-api/index.ts deployment 'edge function is protected deployment work'
+expect_class shared-db/supabase/migrations/fixture.sql shared-db 'vendored database structure retains the governed route'
+expect_class supabase/migrations/fixture.sql shared-db 'historical app migration path retains the governed route'
+expect_class src/integrations/supabase/types.ts shared-db 'generated database contract retains the governed route'
+fixture="$TMP/popdam3"; git -C "$TMP" init --quiet popdam3; git -C "$fixture" config user.name 'Task Gate Test'; git -C "$fixture" config user.email 'task-gate-test@example.invalid'; git -C "$fixture" remote add origin https://github.com/example/popdam-task-gate-fixture.git
+mkdir -p "$fixture/.ai-devops"; cp "$ROOT/.ai-devops/task-gates.json" "$fixture/.ai-devops/task-gates.json"; git -C "$fixture" add .ai-devops/task-gates.json; git -C "$fixture" commit --quiet -m baseline
+( cd "$fixture"; ai-task-gates start --class code --base HEAD >/dev/null; mkdir -p supabase/migrations; printf '%s\n' '-- fixture' > supabase/migrations/fixture.sql )
+assert_blocked(){ local label="$1"; shift; local output rc; set +e; output="$(cd "$fixture" && ai-task-gates check --before ship "$@" 2>&1)"; rc=$?; set -e; if [ "$rc" -eq 3 ]; then pass "$label"; else fail "$label (exit $rc: $output)"; fi; }
+assert_blocked 'shared-db scope escalation refuses shipping'; assert_blocked 'acknowledgement cannot bypass protected database work' --acknowledge 'fixture acknowledgement'; assert_blocked 'owner request cannot bypass protected database work' --owner-request 'fixture owner request'
+( cd "$fixture"; rm -rf supabase; mkdir -p tools; printf '%s\n' 'export const fixture = true;' > tools/fixture.ts; ai-task-gates start --class code --base HEAD >/dev/null; ai-task-gates check --before ship >/dev/null ); pass 'valid code flow proceeds to shipping checks'
+cp "$fixture/.ai-devops/task-gates.json" "$TMP/policy.backup.json"; rm -f "$fixture/.ai-devops/task-gates.json"; printf '%s\n' 'fixtures/task-gates/governed-data/fixture.json' > "$TMP/rollback-path"; without_policy="$(cd "$fixture" && ai-task-gates explain --json --paths-from "$TMP/rollback-path" | jq -r '.observed_class')"; cp "$TMP/policy.backup.json" "$fixture/.ai-devops/task-gates.json"; with_policy="$(cd "$fixture" && ai-task-gates explain --json --paths-from "$TMP/rollback-path" | jq -r '.observed_class')"
+if [ "$without_policy" = code ] && [ "$with_policy" = shared-db ] && cmp -s "$TMP/policy.backup.json" "$fixture/.ai-devops/task-gates.json"; then pass 'rollback removes database escalation and byte-exact restore reinstates it'; else fail "rollback positive control or policy restore failed (without $without_policy, with $with_policy)"; fi
+if [ "$failures" -ne 0 ]; then printf '%s failure(s)\n' "$failures" >&2; exit 1; fi; printf '%s passed / 0 failed\n' "$passes"


### PR DESCRIPTION
Implements the PopDAM row of popcre/ai-devops#335 Phase 4. Adds repository-local classification, refusal/rollback evidence, and pinned CI verification. Local evidence: 16/16 task-gate checks, lint, build, 313/315 parallel tests, with the timeout file passing 5/5 alone and the other failure confirmed as Windows CRLF-only.\n\nRelease hold: every main push triggers a Railway production rebuild. No production deployment is authorized, so this PR remains unmerged. Exact-head review confirms the guards are sound but rejects shipping without release authorization and a green PR Task Gates run.