### PR TITLE
Email terminal bulk-operation failures to hello@popcre.com

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,9 +200,48 @@ Runs on Railway. Environment variables are set in the Railway project dashboard.
 | `OPENROUTER_API_KEY` | Yes | AI tagging and ERP classification — **not the same as admin_config.OPENROUTER_API_KEY** |
 | `META_API_KEY` | No | Meta Model API direct access when Image Tagging selects `meta-direct/muse-spark-1.3-contributor` |
 | `GOOGLE_AI_API_KEY` | No | Legacy fallback if no OpenRouter key |
-| `BULK_OPERATION_ALERT_WEBHOOK_URL` | No until owner selects an existing monitored destination | Receives terminal `rebuild-style-groups` failure alerts; an unset value is logged as an undelivered alert, never treated as success |
+| `BULK_OPERATION_ALERT_WEBHOOK_URL` | Yes once the `bulk-operation-alert` function is deployed | Receives terminal `rebuild-style-groups` failure alerts; an unset value is logged as an undelivered alert, never treated as success. Set it to the deployed `bulk-operation-alert` function URL including its `?key=` shared secret (see below). |
 
 **Critical:** `OPENROUTER_API_KEY` in Railway and `OPENROUTER_API_KEY` in `admin_config` are two separate things. Setting the key in the admin UI (Settings → AI Models) only updates `admin_config`. The Railway worker reads exclusively from Railway ENV variables.
+
+---
+
+## Bulk-operation failure alerts (`supabase/functions/bulk-operation-alert`)
+
+The owner's alert destination is the mailbox **hello@popcre.com**, which is not a webhook.
+The `bulk-operation-alert` edge function is the receiving endpoint: the Railway worker POSTs
+its terminal-failure JSON to the function, and the function emails it via the shared Brevo
+helper (the same path `send-invite-email` uses).
+
+Request body — exactly what `alertTerminalFailure` in `apps/worker/src/terminal-outcomes.ts` sends:
+
+| Field | Notes |
+|-------|-------|
+| `type` | Always `bulk_operation_failed` |
+| `operation` | e.g. `rebuild-style-groups` |
+| `run_id` | Run identifier |
+| `status` | Always `failed` for an alert |
+| `stage` | Optional |
+| `error` | Optional failure message |
+| `reason_code` | Optional |
+| `progress` | Open-ended object; `licensor` / `property` / `style_group` / `scope` keys are rendered as scope lines when present |
+| `started_at`, `ended_at` | ISO timestamps |
+
+Supabase function secrets:
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `BREVO_API_KEY` | Yes | Already used by `send-invite-email` |
+| `BULK_OPERATION_ALERT_SECRET` | Yes | Shared secret. With it unset the function refuses every request with 500 rather than becoming an open mail relay. |
+| `BULK_OPERATION_ALERT_EMAIL_TO` | No | Overrides the default recipient `hello@popcre.com` |
+
+Auth follows the repo's existing `x-agent-key` shape: the shared secret in the `x-alert-key`
+header. Because the worker's alert POST sends only `content-type` and its destination is a bare
+URL, the secret is also accepted as the `key` query parameter — that is the only channel a
+URL-configured webhook has. `verify_jwt = false` for this function; it enforces its own secret.
+
+The function returns 2xx **only** when Brevo accepted the message (502 otherwise), so the
+worker's "alert delivery failed" logging keeps meaning what it says.
 
 ---
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -18,6 +18,11 @@ verify_jwt = false
 [functions.bulk-job-runner]
 verify_jwt = false
 
+# Called machine-to-machine by the Railway worker, which cannot present a JWT.
+# The function enforces its own BULK_OPERATION_ALERT_SECRET shared secret.
+[functions.bulk-operation-alert]
+verify_jwt = false
+
 [functions.export-table]
 verify_jwt = false
 

--- a/supabase/functions/_shared/brevo.ts
+++ b/supabase/functions/_shared/brevo.ts
@@ -9,6 +9,8 @@ interface SendEmailParams {
   to: string;
   subject: string;
   htmlContent: string;
+  /** Optional plain-text alternative for text-only clients. */
+  textContent?: string;
   senderName?: string;
   senderEmail?: string;
 }
@@ -36,12 +38,13 @@ export async function sendBrevoEmail(params: SendEmailParams): Promise<BrevoResu
     email: params.senderEmail ?? "noreply@designflow.app",
   };
 
-  const body = {
+  const body: Record<string, unknown> = {
     sender,
     to: [{ email: params.to }],
     subject: params.subject,
     htmlContent: params.htmlContent,
   };
+  if (params.textContent) body.textContent = params.textContent;
 
   console.log(`[brevo] Sending email to=${params.to} from=${sender.email} subject="${params.subject}"`);
 

--- a/supabase/functions/_shared/bulk-operation-alert.test.ts
+++ b/supabase/functions/_shared/bulk-operation-alert.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  authorizeAlertRequest,
+  buildAlertFields,
+  buildAlertHtml,
+  buildAlertSubject,
+  buildAlertText,
+  type BulkOperationAlertPayload,
+  secretMatches,
+} from "./bulk-operation-alert.ts";
+
+/**
+ * The exact payload apps/worker's `alertTerminalFailure` posts: the whole
+ * TerminalRun spread beside a `type` discriminator.
+ */
+const payload: BulkOperationAlertPayload = {
+  type: "bulk_operation_failed",
+  operation: "style_group_rebuild",
+  run_id: "run_2026_09_10_0001",
+  status: "failed",
+  stage: "assign",
+  error: "ERP lookup timed out after 3 retries",
+  reason_code: "erp_timeout",
+  progress: { processed: 412, total: 900, licensor: "Disney", property: "Mickey & Friends" },
+  started_at: "2026-09-10T04:00:00.000Z",
+  ended_at: "2026-09-10T04:12:31.000Z",
+};
+
+function request(init: { headers?: Record<string, string>; url?: string } = {}) {
+  const headers = new Map(Object.entries(init.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    url: init.url ?? "https://example.supabase.co/functions/v1/bulk-operation-alert",
+    headers: { get: (name: string) => headers.get(name.toLowerCase()) ?? null },
+  };
+}
+
+describe("secretMatches", () => {
+  it("accepts only an exact match", () => {
+    expect(secretMatches("s3cret", "s3cret")).toBe(true);
+    expect(secretMatches("s3cre", "s3cret")).toBe(false);
+    expect(secretMatches("s3cretX", "s3cret")).toBe(false);
+    expect(secretMatches("S3CRET", "s3cret")).toBe(false);
+  });
+
+  it("never authorises when either side is empty", () => {
+    expect(secretMatches("", "")).toBe(false);
+    expect(secretMatches("s3cret", "")).toBe(false);
+    expect(secretMatches("", "s3cret")).toBe(false);
+    expect(secretMatches(null, undefined)).toBe(false);
+  });
+});
+
+describe("authorizeAlertRequest", () => {
+  it("refuses everything when the shared secret is unconfigured", () => {
+    const outcome = authorizeAlertRequest(request({ headers: { "x-alert-key": "anything" } }), "");
+    expect(outcome).toEqual({
+      ok: false,
+      status: 500,
+      error: "Alert endpoint is not configured (BULK_OPERATION_ALERT_SECRET missing)",
+    });
+  });
+
+  it("accepts the shared secret in the x-alert-key header", () => {
+    expect(authorizeAlertRequest(request({ headers: { "x-alert-key": "s3cret" } }), "s3cret")).toEqual({ ok: true });
+  });
+
+  it("accepts the shared secret in the key query parameter, the only channel a webhook URL has", () => {
+    const req = request({ url: "https://example.supabase.co/functions/v1/bulk-operation-alert?key=s3cret" });
+    expect(authorizeAlertRequest(req, "s3cret")).toEqual({ ok: true });
+  });
+
+  it("rejects a wrong or missing secret with 401", () => {
+    expect(authorizeAlertRequest(request(), "s3cret").ok).toBe(false);
+    expect(authorizeAlertRequest(request({ headers: { "x-alert-key": "nope" } }), "s3cret")).toEqual({
+      ok: false,
+      status: 401,
+      error: "Unauthorized",
+    });
+    const wrongQuery = request({ url: "https://example.supabase.co/functions/v1/bulk-operation-alert?key=nope" });
+    expect(authorizeAlertRequest(wrongQuery, "s3cret").ok).toBe(false);
+  });
+});
+
+describe("buildAlertSubject", () => {
+  it("names the operation and run id", () => {
+    expect(buildAlertSubject(payload)).toBe("PopDAM bulk-operation failure: style_group_rebuild (run run_2026_09_10_0001)");
+  });
+
+  it("degrades safely when the worker sent no operation or run id", () => {
+    expect(buildAlertSubject({})).toBe("PopDAM bulk-operation failure: unknown operation");
+  });
+});
+
+describe("buildAlertFields", () => {
+  it("renders every terminal-run field plus licensor/property scope from progress", () => {
+    expect(buildAlertFields(payload)).toEqual([
+      { label: "Operation", value: "style_group_rebuild" },
+      { label: "Run ID", value: "run_2026_09_10_0001" },
+      { label: "Status", value: "failed" },
+      { label: "Stage", value: "assign" },
+      { label: "Reason code", value: "erp_timeout" },
+      { label: "Started", value: "2026-09-10T04:00:00.000Z" },
+      { label: "Ended", value: "2026-09-10T04:12:31.000Z" },
+      { label: "Licensor", value: "Disney" },
+      { label: "Property", value: "Mickey & Friends" },
+      { label: "Error", value: "ERP lookup timed out after 3 retries" },
+    ]);
+  });
+
+  it("omits optional fields the worker did not send", () => {
+    const labels = buildAlertFields({ operation: "erp_classify", run_id: "r1", status: "failed", progress: {} })
+      .map((f) => f.label);
+    expect(labels).toEqual(["Operation", "Run ID", "Status"]);
+  });
+});
+
+describe("buildAlertText", () => {
+  it("puts the run id, error and timestamps in the body", () => {
+    const text = buildAlertText(payload);
+    expect(text).toContain("Run ID: run_2026_09_10_0001");
+    expect(text).toContain("Error: ERP lookup timed out after 3 retries");
+    expect(text).toContain("Ended: 2026-09-10T04:12:31.000Z");
+    expect(text).toContain('"processed": 412');
+  });
+});
+
+describe("buildAlertHtml", () => {
+  it("escapes payload text so a hostile error string cannot inject markup", () => {
+    const html = buildAlertHtml({ ...payload, error: '<img src=x onerror="alert(1)">' });
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+  });
+
+  it("escapes ampersands in scope values", () => {
+    expect(buildAlertHtml(payload)).toContain("Mickey &amp; Friends");
+  });
+
+  it("renders without a progress block when progress is empty", () => {
+    expect(buildAlertHtml({ operation: "x", run_id: "y", progress: {} })).not.toContain("Progress</h3>");
+  });
+});

--- a/supabase/functions/_shared/bulk-operation-alert.ts
+++ b/supabase/functions/_shared/bulk-operation-alert.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure logic for the `bulk-operation-alert` edge function.
+ *
+ * The Railway worker (apps/worker) POSTs a terminal bulk-operation failure to
+ * whatever URL is configured in BULK_OPERATION_ALERT_WEBHOOK_URL. The owner has
+ * named a mailbox rather than a webhook, so this module turns that JSON payload
+ * into a readable email. Everything here is side-effect free so it can be unit
+ * tested by the repo's vitest edge-function project; the Deno handler in
+ * ../bulk-operation-alert/index.ts owns I/O only.
+ */
+
+/** The payload shape produced by `alertTerminalFailure` in apps/worker. */
+export interface BulkOperationAlertPayload {
+  type?: string;
+  operation?: string;
+  run_id?: string;
+  status?: string;
+  stage?: string;
+  error?: string;
+  reason_code?: string;
+  progress?: Record<string, unknown>;
+  started_at?: string;
+  ended_at?: string;
+}
+
+export type AuthOutcome =
+  | { ok: true }
+  | { ok: false; status: 401 | 500; error: string };
+
+/**
+ * Exact, length-guarded comparison of a presented secret against the expected
+ * one. Never a substring or prefix match, and never true when either side is
+ * empty, so an unset env var can never authorise a caller.
+ */
+export function secretMatches(presented: string | null | undefined, expected: string | null | undefined): boolean {
+  if (!presented || !expected) return false;
+  if (presented.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < presented.length; i++) diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Machine-to-machine auth, following the repo's existing `x-agent-key` shape:
+ * a single shared secret carried in a request header.
+ *
+ * The worker's alert POST sends only `content-type`, and its destination is a
+ * bare URL, so the secret is also accepted as the `key` query parameter — that
+ * is the only channel a URL-configured webhook has today. Neither channel is
+ * optional: with BULK_OPERATION_ALERT_SECRET unset the function refuses every
+ * request rather than becoming an open mail relay.
+ */
+export function authorizeAlertRequest(
+  req: { headers: { get(name: string): string | null }; url: string },
+  expectedSecret: string | null | undefined,
+): AuthOutcome {
+  if (!expectedSecret) {
+    return { ok: false, status: 500, error: "Alert endpoint is not configured (BULK_OPERATION_ALERT_SECRET missing)" };
+  }
+  const header = req.headers.get("x-alert-key");
+  if (secretMatches(header, expectedSecret)) return { ok: true };
+
+  let queryKey: string | null = null;
+  try {
+    queryKey = new URL(req.url).searchParams.get("key");
+  } catch {
+    queryKey = null;
+  }
+  if (secretMatches(queryKey, expectedSecret)) return { ok: true };
+
+  return { ok: false, status: 401, error: "Unauthorized" };
+}
+
+function present(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Scope fields the worker may attach to `progress` for a style-group rebuild or
+ * a licensor/property-scoped run. Absent keys are simply not rendered — the
+ * worker's progress object is deliberately open-ended.
+ */
+const SCOPE_KEYS = ["licensor", "licensor_name", "property", "property_name", "style_group", "scope", "brand", "batch"] as const;
+
+export interface AlertField {
+  label: string;
+  value: string;
+}
+
+/** Ordered, human-labelled fields for the email body. Only present values appear. */
+export function buildAlertFields(payload: BulkOperationAlertPayload): AlertField[] {
+  const fields: AlertField[] = [];
+  const push = (label: string, value: unknown) => {
+    const v = present(value);
+    if (v) fields.push({ label, value: v });
+  };
+
+  push("Operation", payload.operation);
+  push("Run ID", payload.run_id);
+  push("Status", payload.status);
+  push("Stage", payload.stage);
+  push("Reason code", payload.reason_code);
+  push("Started", payload.started_at);
+  push("Ended", payload.ended_at);
+
+  const progress = payload.progress;
+  if (progress && typeof progress === "object") {
+    for (const key of SCOPE_KEYS) {
+      const raw = (progress as Record<string, unknown>)[key];
+      if (typeof raw === "string" || typeof raw === "number") {
+        push(key.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase()), String(raw));
+      }
+    }
+  }
+
+  push("Error", payload.error);
+  return fields;
+}
+
+/** Subject line naming this unambiguously as a PopDAM bulk-operation failure. */
+export function buildAlertSubject(payload: BulkOperationAlertPayload): string {
+  const operation = present(payload.operation) ?? "unknown operation";
+  const runId = present(payload.run_id);
+  return runId
+    ? `PopDAM bulk-operation failure: ${operation} (run ${runId})`
+    : `PopDAM bulk-operation failure: ${operation}`;
+}
+
+/** Plain-text rendering, also used as the fallback body for text-only clients. */
+export function buildAlertText(payload: BulkOperationAlertPayload): string {
+  const lines = [buildAlertSubject(payload), ""];
+  for (const { label, value } of buildAlertFields(payload)) lines.push(`${label}: ${value}`);
+
+  const progress = payload.progress;
+  if (progress && typeof progress === "object" && Object.keys(progress).length > 0) {
+    lines.push("", "Progress:", JSON.stringify(progress, null, 2));
+  }
+  lines.push("", "Sent by the PopDAM bulk-operation alert endpoint.");
+  return lines.join("\n");
+}
+
+/** HTML rendering in the same visual language as the PopDAM invite email. */
+export function buildAlertHtml(payload: BulkOperationAlertPayload): string {
+  const rows = buildAlertFields(payload)
+    .map(({ label, value }) =>
+      `<tr><td style="padding:6px 12px 6px 0;color:#71717a;font-size:13px;vertical-align:top;white-space:nowrap;">${escapeHtml(label)}</td>` +
+      `<td style="padding:6px 0;color:#18181b;font-size:13px;word-break:break-word;">${escapeHtml(value)}</td></tr>`
+    )
+    .join("");
+
+  const progress = payload.progress;
+  const progressBlock = progress && typeof progress === "object" && Object.keys(progress).length > 0
+    ? `<h3 style="margin:24px 0 8px;color:#18181b;font-size:14px;font-weight:600;">Progress</h3>` +
+      `<pre style="margin:0;padding:12px;background:#f4f4f5;border-radius:6px;color:#3f3f46;font-size:12px;white-space:pre-wrap;word-break:break-word;">${
+        escapeHtml(JSON.stringify(progress, null, 2))
+      }</pre>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <tr><td style="background:#7f1d1d;padding:20px 32px;">
+          <h1 style="margin:0;color:#ffffff;font-size:18px;font-weight:600;">PopDAM bulk-operation failure</h1>
+        </td></tr>
+        <tr><td style="padding:28px 32px;">
+          <table cellpadding="0" cellspacing="0" width="100%">${rows}</table>
+          ${progressBlock}
+          <p style="margin:24px 0 0;color:#a1a1aa;font-size:12px;line-height:1.5;">
+            Sent by the PopDAM bulk-operation alert endpoint.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/supabase/functions/_shared/bulk-operation-alert.ts
+++ b/supabase/functions/_shared/bulk-operation-alert.ts
@@ -132,9 +132,7 @@ export function buildAlertFields(payload: BulkOperationAlertPayload): AlertField
 export function buildAlertSubject(payload: BulkOperationAlertPayload): string {
   const operation = present(payload.operation) ?? "unknown operation";
   const runId = present(payload.run_id);
-  return runId
-    ? `PopDAM bulk-operation failure: ${operation} (run ${runId})`
-    : `PopDAM bulk-operation failure: ${operation}`;
+  return runId ? `PopDAM bulk-operation failure: ${operation} (run ${runId})` : `PopDAM bulk-operation failure: ${operation}`;
 }
 
 /** Plain-text rendering, also used as the fallback body for text-only clients. */

--- a/supabase/functions/bulk-operation-alert/index.ts
+++ b/supabase/functions/bulk-operation-alert/index.ts
@@ -1,0 +1,67 @@
+/**
+ * bulk-operation-alert — email destination for terminal bulk-operation failures.
+ *
+ * The Railway worker (apps/worker) POSTs a terminal failure to the URL held in
+ * BULK_OPERATION_ALERT_WEBHOOK_URL. The owner named a mailbox (hello@popcre.com)
+ * rather than a webhook, so this function receives that POST and sends the
+ * payload on as an email through the repo's existing Brevo helper.
+ *
+ * It returns 2xx ONLY when Brevo accepted the message, so the worker's
+ * "alert delivery failed" logging keeps meaning what it says.
+ *
+ * Configuration (Supabase function secrets):
+ *   BREVO_API_KEY                  — already used by send-invite-email
+ *   BULK_OPERATION_ALERT_SECRET    — shared secret; required, no default
+ *   BULK_OPERATION_ALERT_EMAIL_TO  — optional override of the default recipient
+ */
+
+import { corsServe, json } from "../_shared/http.ts";
+import { sendBrevoEmail } from "../_shared/brevo.ts";
+import {
+  authorizeAlertRequest,
+  buildAlertHtml,
+  buildAlertSubject,
+  buildAlertText,
+  type BulkOperationAlertPayload,
+} from "../_shared/bulk-operation-alert.ts";
+
+const DEFAULT_RECIPIENT = "hello@popcre.com";
+
+corsServe(async (req: Request) => {
+  if (req.method !== "POST") return json({ ok: false, error: "Method not allowed" }, 405);
+
+  const auth = authorizeAlertRequest(req, Deno.env.get("BULK_OPERATION_ALERT_SECRET"));
+  if (!auth.ok) {
+    console.error(`[bulk-operation-alert] refused: ${auth.error}`);
+    return json({ ok: false, error: auth.error }, auth.status);
+  }
+
+  let payload: BulkOperationAlertPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ ok: false, error: "Body must be JSON" }, 400);
+  }
+  if (!payload || typeof payload !== "object") {
+    return json({ ok: false, error: "Body must be a JSON object" }, 400);
+  }
+
+  const to = Deno.env.get("BULK_OPERATION_ALERT_EMAIL_TO")?.trim() || DEFAULT_RECIPIENT;
+  const subject = buildAlertSubject(payload);
+
+  const result = await sendBrevoEmail({
+    to,
+    subject,
+    htmlContent: buildAlertHtml(payload),
+    textContent: buildAlertText(payload),
+  });
+
+  if (!result.ok) {
+    // Non-2xx keeps the worker's undelivered-alert logging honest.
+    console.error(`[bulk-operation-alert] send failed for run=${payload.run_id ?? "unknown"}: ${result.error}`);
+    return json({ ok: false, error: result.error, httpStatus: result.httpStatus }, 502);
+  }
+
+  console.log(`[bulk-operation-alert] delivered run=${payload.run_id ?? "unknown"} messageId=${result.messageId ?? "none"}`);
+  return json({ ok: true, sent: true, messageId: result.messageId ?? null, warning: result.warning ?? null });
+});

--- a/supabase/functions/bulk-operation-alert/index.ts
+++ b/supabase/functions/bulk-operation-alert/index.ts
@@ -17,13 +17,7 @@
 
 import { corsServe, json } from "../_shared/http.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
-import {
-  authorizeAlertRequest,
-  buildAlertHtml,
-  buildAlertSubject,
-  buildAlertText,
-  type BulkOperationAlertPayload,
-} from "../_shared/bulk-operation-alert.ts";
+import { authorizeAlertRequest, buildAlertHtml, buildAlertSubject, buildAlertText, type BulkOperationAlertPayload } from "../_shared/bulk-operation-alert.ts";
 
 const DEFAULT_RECIPIENT = "hello@popcre.com";
 


### PR DESCRIPTION
## Why

PR #120 / issue #117 made the Railway worker POST a structured terminal-failure payload to whatever URL sits in `BULK_OPERATION_ALERT_WEBHOOK_URL`. The owner has now named the alert destination: the mailbox **hello@popcre.com**. An email address is not a webhook URL, so this adds the receiving endpoint.

## What

New Supabase edge function `supabase/functions/bulk-operation-alert`:

- Accepts a POST of the exact payload `alertTerminalFailure` sends — `type`, `operation`, `run_id`, `status`, `stage`, `error`, `reason_code`, `progress`, `started_at`, `ended_at`.
- Renders it as a readable plain-text **and** HTML email: run id, operation, stage, reason code, timestamps, error, plus licensor / property / style-group scope when the worker put those keys in `progress`. Subject: `PopDAM bulk-operation failure: <operation> (run <id>)`.
- Sends it with the existing `sendBrevoEmail` helper — the same path `send-invite-email` uses. `sendBrevoEmail` gains an optional `textContent` field (backwards compatible).
- **Auth:** a shared secret, following the repo's existing `x-agent-key` convention — `x-alert-key` header, or the `key` query parameter, since the worker's alert POST sends only `content-type` and its destination is a bare URL. Read from `BULK_OPERATION_ALERT_SECRET`; nothing hardcoded. With that secret unset the function refuses **every** request with 500 rather than becoming an open mail relay. Comparison is exact and length-guarded, never a substring match.
- **Returns 2xx only on a successful send** (502 otherwise), so the worker's "undelivered alert" logging keeps meaning what it says.

Testable logic lives in `supabase/functions/_shared/bulk-operation-alert.ts` with 14 vitest cases in the repo's existing `edge-functions` project, covering auth acceptance/rejection, the unconfigured-secret refusal, field rendering, subject fallback, and HTML escaping of a hostile error string.

Nothing was deployed and no Railway setting was changed.

## Operator action required

After this is deployed, the operator must set `BULK_OPERATION_ALERT_WEBHOOK_URL` in Railway to the deployed function URL, including the shared secret:

```
https://<project>.supabase.co/functions/v1/bulk-operation-alert?key=<BULK_OPERATION_ALERT_SECRET>
```

and set the Supabase function secret `BULK_OPERATION_ALERT_SECRET` (plus confirm `BREVO_API_KEY` is present). Until both are set, failures are logged as undelivered rather than emailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
