### PR TITLE
Fix effective asset exact-count materialization (#127, shared-db #2501)

### DIFF
--- a/docs/verification/effective-asset-count-2501.md
+++ b/docs/verification/effective-asset-count-2501.md
@@ -1,0 +1,82 @@
+# Effective asset counts and grouped-filter activation
+
+PopDAM issue #127 implements the application portion of shared-db issue #2501.
+
+## Release prerequisite
+
+The application must not ship before shared-db migration `20260911052640` is
+verified in production. Shared-db PR #2734 merged as
+`84a1a1d76a79d1d3d9f45c106c6722cec9eeed5c`; its preview apply succeeded in
+[run 34581214593](https://github.com/u2giants/shared-db/actions/runs/34581214593).
+Production [run 34595295842](https://github.com/u2giants/shared-db/actions/runs/34595295842)
+succeeded against exact main `d530f85bc54d2b3c1f3ac52fcb9ee8d57c17fe3e`.
+The production ledger contains the migration and all three indexes are valid and
+ready. The immutable apply artifact is `10262431870`, digest
+`sha256:d89ea12c3db55e0aaf5261d7f40e0cdb0224dbf05216d5c437e73f06d245270a`.
+No database change is authored by this application patch.
+
+## Corrected request shape
+
+An exact count on the full-row RPC materializes every matching wide asset.
+The application now fetches the original full-row page separately from an
+ID-only exact count. The SDK converts a JSON-object RPC argument with
+`head: true` to POST; appending `select()` requests a response body again.
+Serializing the JSON argument retains a real HEAD request. An explicit one-row
+range also bounds the request. Tests inspect the actual SDK-produced method,
+query string, exact-count preference, absent response body, and full page shape.
+
+Effective-scope page, facet and count requests are serialized. Running all three
+together twice reproduced the database's bounded eight-second timeout, first on
+the count and then on the page. Serial execution keeps ordinary asset queries
+concurrent while preventing those three requests from competing for the same
+effective-metadata working set.
+
+All requests retain deletion, visibility, search IDs or fallback, and every
+additional library filter. Failures in either request fail the library query;
+an unavailable total is not presented as zero. Category and file-status choices
+are also forwarded to the existing facet contract. Existing keyword facet
+search semantics are unchanged.
+
+Category filtering uses the contract's existing category/path predicate instead
+of repeating its OR outside the RPC. An outer category OR timed out at 7.8s;
+adding it both inside and outside still timed out. Applying the identical
+supported predicate inside alone passed, with the first count taking 5.5s and
+matching the facet total. Unsupported category choices remain ignored.
+
+## Authenticated preview proof
+
+On 2026-09-11 the sealed viewer logged into preview project
+`mvpkijzfmfcxhnzqogzs`; its JWT role, subject and issuer were checked before reads.
+Each case ran twice with the app's deletion and visibility predicates, full
+pages 0 and 1, ID-only exact HEAD count, and facet total:
+
+- Tag: 27,146.
+- Licensor: 92.
+- Property: 129.
+- Combined tag/licensor/property: 0.
+- Mixed tag/file-type/stage: 2,063.
+- Tag plus Wall category: 12,120.
+- Tag plus Has Preview: 27,053.
+
+Every total agreed, both pages retained full fields, and there were no duplicate
+IDs across the two pages. The first tag/mixed run completed its 16 calls in
+156–1,725 ms. Fixture identifiers, licensed rows, and credentials are excluded.
+
+Category/file-status qualification also passed twice, with full pages and exact
+facet parity. A final concurrency acceptance alternated facet-first and
+page-first order for all seven shapes, twice each. All 42 primary requests and
+14 second-page reads passed; the coldest tag page was 3,054 ms and count 1,664 ms,
+then 605 ms and 500 ms warm. The coldest category page was 1,528 ms and count
+1,268 ms. Production visual verification remains pending.
+
+## Local checks
+
+- Focused SDK, hook, filtering and search tests: 22 passed, none skipped. The
+  suite verifies that effective page, facets and count never overlap and that
+  the exact count starts only after the visible page completes.
+- Production build and full lint: passed.
+- Earlier full Windows suite: 334 passed, two existing failures. The registry
+  test assumes LF in a CRLF checkout; the export test exceeded its parallel
+  five-second limit and passed alone. Neither failure concerns modified code.
+- Standalone type checking reports existing errors in unrelated files; neither
+  modified file has a reported type error.

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -168,12 +168,29 @@ const EFFECTIVE_SCOPE_CONTRACT_READY = true;
 // queries remain concurrent.
 let effectiveScopeQueryTail: Promise<void> = Promise.resolve();
 
-async function runEffectiveScopeQuery<T>(query: () => PromiseLike<T>): Promise<T> {
+function abortError(): Error {
+  const error = new Error("Effective-scope query was superseded");
+  error.name = "AbortError";
+  return error;
+}
+
+/**
+ * Serializes effective-scope RPCs. When React Query cancels an obsolete query
+ * (for example after a filter change), its signal both aborts the in-flight
+ * request and skips work still waiting in the queue, so stale filters never
+ * hold the slot ahead of the current one.
+ */
+export async function runEffectiveScopeQuery<T>(
+  query: () => PromiseLike<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) throw abortError();
   const previous = effectiveScopeQueryTail.catch(() => undefined);
   let release!: () => void;
   effectiveScopeQueryTail = new Promise<void>((resolve) => { release = resolve; });
-  await previous;
   try {
+    await previous;
+    if (signal?.aborted) throw abortError();
     return await query();
   } finally {
     release();
@@ -348,7 +365,7 @@ export function useAssets(
   return useQuery({
     queryKey: ["assets", filters, sortField, sortDirection, page, visibilityDate, effectivePageSize],
     enabled,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const from = page * effectivePageSize;
       const to = from + effectivePageSize - 1;
       const minDate = visibilityDate ?? "2020-01-01";
@@ -411,10 +428,13 @@ export function useAssets(
       // the useful first unit of work, and the narrow count follows once it has
       // released its database work.
       const pageResult = effectiveScope
-        ? await runEffectiveScopeQuery(() => query)
+        ? await runEffectiveScopeQuery(() => query.abortSignal(signal), signal)
         : await query;
       const countResult = effectiveScope
-        ? await runEffectiveScopeQuery(() => buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter, true))
+        ? await runEffectiveScopeQuery(
+            () => buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter, true).abortSignal(signal),
+            signal,
+          )
         : null;
       const { data, error } = pageResult;
       if (error) throw error;
@@ -437,7 +457,7 @@ export function useAssets(
 export function useAssetCount(filters: AssetFilters, visibilityDate?: string) {
   return useQuery({
     queryKey: ["asset-count", filters, visibilityDate],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const searchTerm = filters.search?.replace(/[(),]/g, " ").trim();
       if (searchTerm && await getSearchMode() === "hybrid") {
         try {
@@ -457,7 +477,7 @@ export function useAssetCount(filters: AssetFilters, visibilityDate?: string) {
 
       const query = buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter);
       const { count, error } = needsEffectiveScope(filters)
-        ? await runEffectiveScopeQuery(() => query)
+        ? await runEffectiveScopeQuery(() => query.abortSignal(signal), signal)
         : await query;
       if (error) throw error;
       return count ?? 0;
@@ -475,7 +495,7 @@ export function useAssetCount(filters: AssetFilters, visibilityDate?: string) {
 export function useFilterCounts(filters: AssetFilters) {
   return useQuery({
     queryKey: ["filter-counts", filters],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const searchTerm = filters.search?.replace(/[(),]/g, " ").trim();
       if (searchTerm && await getSearchMode() === "hybrid") {
         try {
@@ -514,7 +534,7 @@ export function useFilterCounts(filters: AssetFilters) {
         p_filters: filterPayload as unknown as Json,
       });
       const { data, error } = needsEffectiveScope(filters)
-        ? await runEffectiveScopeQuery(() => facetQuery)
+        ? await runEffectiveScopeQuery(() => facetQuery.abortSignal(signal), signal)
         : await facetQuery;
       if (error) throw error;
       return (data ?? {}) as unknown as FacetCounts;

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -430,14 +430,16 @@ export function useAssets(
       const pageResult = effectiveScope
         ? await runEffectiveScopeQuery(() => query.abortSignal(signal), signal)
         : await query;
+      const { data, error } = pageResult;
+      // A failed page (for example a timeout) must not start the exact count:
+      // that would add database work, hold the queue, and delay the error.
+      if (error) throw error;
       const countResult = effectiveScope
         ? await runEffectiveScopeQuery(
             () => buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter, true).abortSignal(signal),
             signal,
           )
         : null;
-      const { data, error } = pageResult;
-      if (error) throw error;
       if (countResult?.error) throw countResult.error;
       const count = countResult ? countResult.count : pageResult.count;
 

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -154,30 +154,31 @@ async function fetchAssetFullTextIds(search: string) {
  * `public.filter_effective_assets`, which resolves both scopes server-side.
  */
 /**
- * ⛔ OFF. Rows are fixed; counting a tag filter still is not.
- *
- * Re-measured against production as a real `authenticated` user on 2026-09-03,
- * after shared-db 20260903075635 reached production. 3 consecutive calls each:
- *
- *   rows, 5 and 200, no filter, no count -> 3/3 pass @ 0.19-0.40s  ✅
- *   rows, 200, licensorId                -> 3/3 pass @ 0.12-0.32s  ✅
- *   rows, 200, tagFilter                 -> pass @ 1.3-2.1s        ✅
- *   get_filter_counts {} and {licensorId}-> 3/3 pass @ 0.12-1.22s  ✅
- *   get_filter_counts {tagFilter}        -> 0/12 across four tags, ~8.1s
- *   filter_effective_assets count=exact  -> 0/3, ~8.1s
- *
- * So the tag predicate itself is fine and indexed — the ROW path filters by tag
- * in 1.3s — but counting that same set times out. Tracked as
- * u2giants/shared-db#2138.
- *
- * Turning this on needs a list total. Either `count=exact` starts completing,
- * or this hook takes the total from `get_filter_counts.total` instead — but that
- * only works once the counts call is reliable for EVERY effective filter, tags
- * included. Measure several consecutive calls per filter type before flipping:
- * a single warm call has passed at every stage of this while the real shapes
- * failed.
+ * Enabled after shared-db #2501 preview qualification with migration
+ * 20260911052640: repeated authenticated tag/licensor/property/mixed-filter
+ * pages, exact ID HEAD totals, and facets agree. Deploy with that migration.
+ * Keep full rows separate from exact counts; wide counted RPCs materialize
+ * every matching asset (the previous shared-db#2138 blocker).
  */
-const EFFECTIVE_SCOPE_CONTRACT_READY = false;
+const EFFECTIVE_SCOPE_CONTRACT_READY = true;
+
+// These RPCs share the same effective-metadata working set. Running a page,
+// facets, and an exact count together can push one request into the database's
+// bounded timeout. Keep only this expensive scope serial; ordinary asset
+// queries remain concurrent.
+let effectiveScopeQueryTail: Promise<void> = Promise.resolve();
+
+async function runEffectiveScopeQuery<T>(query: () => PromiseLike<T>): Promise<T> {
+  const previous = effectiveScopeQueryTail.catch(() => undefined);
+  let release!: () => void;
+  effectiveScopeQueryTail = new Promise<void>((resolve) => { release = resolve; });
+  await previous;
+  try {
+    return await query();
+  } finally {
+    release();
+  }
+}
 
 export function needsEffectiveScope(filters: AssetFilters): boolean {
   if (!EFFECTIVE_SCOPE_CONTRACT_READY) return false;
@@ -189,12 +190,21 @@ export function wouldNeedEffectiveScope(filters: AssetFilters): boolean {
   return Boolean(filters.tagFilter || filters.licensorId || filters.propertyId);
 }
 
-/** The subset of the filter payload the effective contract owns. */
+function supportedProductCategories(categories: string[]): string[] {
+  return categories.map((category) => category.trim())
+    .filter((category) => buildProductCategoryOrFilter([category], "relative_path"));
+}
+
+/** The subset of the filter payload delegated to the effective contract. */
 export function buildEffectiveFilterPayload(filters: AssetFilters): Record<string, unknown> {
   const payload: Record<string, unknown> = {};
   if (filters.tagFilter) payload.tagFilter = filters.tagFilter;
   if (filters.licensorId) payload.licensorId = filters.licensorId;
   if (filters.propertyId) payload.propertyId = filters.propertyId;
+  // The contract implements the same category/path alternatives. Keeping this
+  // predicate inside the RPC avoids materializing the effective set before OR.
+  const productCategory = supportedProductCategories(filters.productCategory);
+  if (productCategory.length > 0) payload.productCategory = productCategory;
   return payload;
 }
 
@@ -262,7 +272,7 @@ function applyFilters(
   if (filters.artSource.length > 0) {
     query = query.in("art_source", filters.artSource);
   }
-  if (filters.productCategory.length > 0) {
+  if (!effectiveScopeApplied && filters.productCategory.length > 0) {
     const categoryFilter = buildProductCategoryOrFilter(filters.productCategory, "relative_path");
     if (categoryFilter) query = query.or(categoryFilter);
   }
@@ -299,6 +309,29 @@ function applyFilters(
 function applyVisibility(query: any, minDate: string) {
   return query.or(
     `modified_at.gte.${minDate},file_created_at.gte.${minDate},thumbnail_url.not.is.null`
+  );
+}
+
+/** Keep exact totals narrow while applying the same scope as the full-row page. */
+export function buildAssetCountQuery(
+  filters: AssetFilters,
+  minDate: string,
+  fullTextAssetIds?: string[] | null,
+  fallbackSearchFilter?: string | null,
+  effectiveScope = needsEffectiveScope(filters),
+) {
+  const query = effectiveScope
+    ? supabase.rpc(
+        "filter_effective_assets",
+        // A JSON string keeps this a true HEAD. Supabase sends object arguments
+        // as POST, and select() would then request a response body again.
+        { p_filters: JSON.stringify(buildEffectiveFilterPayload(filters)) },
+        { count: "exact", head: true },
+      ).select("id").range(0, 0)
+    : supabase.from("assets").select("id", { count: "exact", head: true });
+  return applyVisibility(
+    applyFilters(query, filters, fullTextAssetIds, fallbackSearchFilter, effectiveScope),
+    minDate,
   );
 }
 
@@ -354,7 +387,6 @@ export function useAssets(
         ? supabase.rpc(
             "filter_effective_assets",
             { p_filters: buildEffectiveFilterPayload(filters) as unknown as Json },
-            { count: "exact" },
           )
         : supabase.from("assets").select("*", { count: "exact" });
 
@@ -371,8 +403,23 @@ export function useAssets(
         query = query.range(from, to);
       }
 
-      const { data, error, count } = await query;
+      // An exact count on a wide RPC materializes every matching asset. Fetch
+      // full rows only for the page, and count the identical filtered IDs.
+      // Fetch the visible page before the exact total. Starting page, facets,
+      // and the effective-scope count together can make the otherwise-fast
+      // count contend until the server's eight-second limit. The page remains
+      // the useful first unit of work, and the narrow count follows once it has
+      // released its database work.
+      const pageResult = effectiveScope
+        ? await runEffectiveScopeQuery(() => query)
+        : await query;
+      const countResult = effectiveScope
+        ? await runEffectiveScopeQuery(() => buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter, true))
+        : null;
+      const { data, error } = pageResult;
       if (error) throw error;
+      if (countResult?.error) throw countResult.error;
+      const count = countResult ? countResult.count : pageResult.count;
 
       const assets = useRelevance
         ? sortByRank((data ?? []) as Asset[], fullTextAssetIds!, (asset) => asset.id).slice(from, to + 1)
@@ -408,18 +455,10 @@ export function useAssetCount(filters: AssetFilters, visibilityDate?: string) {
       const minDate = visibilityDate ?? "2020-01-01";
       const { ids: fullTextAssetIds, fallback: fallbackSearchFilter } = await resolveAssetSearch(filters.search);
 
-      const effectiveScope = needsEffectiveScope(filters);
-      let query: any = effectiveScope
-        ? supabase.rpc(
-            "filter_effective_assets",
-            { p_filters: buildEffectiveFilterPayload(filters) as unknown as Json },
-            { count: "exact", head: true },
-          )
-        : supabase.from("assets").select("*", { count: "exact", head: true });
-
-      query = applyFilters(query, filters, fullTextAssetIds, fallbackSearchFilter, effectiveScope);
-      query = applyVisibility(query, minDate);
-      const { count, error } = await query;
+      const query = buildAssetCountQuery(filters, minDate, fullTextAssetIds, fallbackSearchFilter);
+      const { count, error } = needsEffectiveScope(filters)
+        ? await runEffectiveScopeQuery(() => query)
+        : await query;
       if (error) throw error;
       return count ?? 0;
     },
@@ -467,10 +506,16 @@ export function useFilterCounts(filters: AssetFilters) {
       if (filters.stage.length > 0) filterPayload.stage = filters.stage;
       if (filters.customer) filterPayload.customer = filters.customer;
       if (filters.program) filterPayload.program = filters.program;
+      const productCategory = supportedProductCategories(filters.productCategory);
+      if (productCategory.length > 0) filterPayload.productCategory = productCategory;
+      if (filters.fileStatus.length > 0) filterPayload.fileStatus = filters.fileStatus;
 
-      const { data, error } = await supabase.rpc("get_filter_counts", {
+      const facetQuery = supabase.rpc("get_filter_counts", {
         p_filters: filterPayload as unknown as Json,
       });
+      const { data, error } = needsEffectiveScope(filters)
+        ? await runEffectiveScopeQuery(() => facetQuery)
+        : await facetQuery;
       if (error) throw error;
       return (data ?? {}) as unknown as FacetCounts;
     },

--- a/src/test/effective-asset-filtering.test.ts
+++ b/src/test/effective-asset-filtering.test.ts
@@ -163,6 +163,23 @@ describe("active grouped library requests", () => {
     await expect(options.queryFn({ signal: new AbortController().signal })).rejects.toBeTruthy();
   });
 
+  it("surfaces a failed page without starting the exact count", async () => {
+    const methods: string[] = [];
+    const fetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      methods.push(init?.method ?? "GET");
+      return new Response(JSON.stringify({ message: "canceling statement due to statement timeout", code: "57014" }), {
+        status: 500, headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = createClient("https://example.supabase.co", "test-key", {
+      global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
+    });
+    rpc.mockImplementation((...args) => (client.rpc as any)(...args));
+    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    await expect(options.queryFn({ signal: new AbortController().signal })).rejects.toBeTruthy();
+    expect(methods).toEqual(["POST"]); // no HEAD count after the page failed
+  });
+
   it("uses the same narrow count for standalone library totals", async () => {
     const fetch = installClient();
     const options = useAssetCount(filters({ tagFilter: "blue" })) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<number> };

--- a/src/test/effective-asset-filtering.test.ts
+++ b/src/test/effective-asset-filtering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createClient } from "@supabase/supabase-js";
 
 /**
  * The library must filter and count by EFFECTIVE metadata — the union of what
@@ -13,6 +14,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const rpc = vi.fn();
 const from = vi.fn();
+vi.mock("@tanstack/react-query", () => ({ useQuery: (options: unknown) => options }));
 
 vi.mock("@/integrations/supabase/client", () => ({
   supabase: {
@@ -23,8 +25,12 @@ vi.mock("@/integrations/supabase/client", () => ({
 
 import {
   buildEffectiveFilterPayload,
+  buildAssetCountQuery,
   needsEffectiveScope,
   wouldNeedEffectiveScope,
+  useAssets,
+  useAssetCount,
+  useFilterCounts,
 } from "@/hooks/useAssets";
 import type { AssetFilters } from "@/types/assets";
 
@@ -56,6 +62,206 @@ beforeEach(() => {
   from.mockReset();
 });
 
+describe("active grouped library requests", () => {
+  function installClient(failCount = false) {
+    const fetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") return new Response(null, {
+        status: failCount ? 500 : 206, headers: { "content-range": "0-0/401" },
+      });
+      return new Response(JSON.stringify([{ id: "a1", filename: "full.psd", relative_path: "art/full.psd", file_size: 123 }]), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = createClient("https://example.supabase.co", "test-key", {
+      global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
+    });
+    rpc.mockImplementation((...args) => (client.rpc as any)(...args));
+    return fetch;
+  }
+
+  it("retains full page rows and exact totals while separating the requests", async () => {
+    const fetch = installClient();
+    const options = useAssets(filters({ tagFilter: "blue", stage: ["dev"], productCategory: ["Wall"] }), "modified_at", "desc", 1) as unknown as { queryFn: () => Promise<any> };
+    const result = await options.queryFn();
+    expect(result).toEqual({ assets: [{ id: "a1", filename: "full.psd", relative_path: "art/full.psd", file_size: 123 }], totalCount: 401, pageSize: 200, page: 1 });
+    const page = fetch.mock.calls.find(([, init]) => init?.method === "POST")!;
+    const head = fetch.mock.calls.find(([, init]) => init?.method === "HEAD")!;
+    const pageParams = new URL(String(page[0])).searchParams;
+    const headParams = new URL(String(head[0])).searchParams;
+    expect(pageParams.get("select")).toBeNull(); // Full RPC rows remain intact.
+    expect(pageParams.get("offset")).toBe("200");
+    expect(pageParams.get("limit")).toBe("200");
+    expect(new Headers(page[1]?.headers).get("Prefer") ?? "").not.toContain("count=exact");
+    for (const key of ["stage", "is_deleted", "or"]) expect(headParams.getAll(key)).toEqual(pageParams.getAll(key));
+    expect(headParams.get("select")).toBe("id");
+    expect(JSON.parse(String(page[1]?.body)).p_filters).toEqual({ tagFilter: "blue", productCategory: ["Wall"] });
+    expect(JSON.parse(headParams.get("p_filters")!)).toEqual({ tagFilter: "blue", productCategory: ["Wall"] });
+    expect(pageParams.getAll("or").join()).not.toContain("product_category");
+  });
+
+  it("finishes the visible page before starting the exact count", async () => {
+    let releasePage!: () => void;
+    const pageReleased = new Promise<void>((resolve) => { releasePage = resolve; });
+    const methods: string[] = [];
+    const fetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      methods.push(init?.method ?? "GET");
+      if (init?.method === "POST") {
+        await pageReleased;
+        return new Response(JSON.stringify([{ id: "a1", filename: "full.psd", relative_path: "art/full.psd" }]), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(null, { status: 206, headers: { "content-range": "0-0/401" } });
+    });
+    const client = createClient("https://example.supabase.co", "test-key", {
+      global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
+    });
+    rpc.mockImplementation((...args) => (client.rpc as any)(...args));
+    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
+    const result = options.queryFn();
+    await vi.waitFor(() => expect(methods).toEqual(["POST"]));
+    releasePage();
+    await expect(result).resolves.toMatchObject({ totalCount: 401 });
+    expect(methods).toEqual(["POST", "HEAD"]);
+  });
+
+  it("serializes page, facets, and count for the effective scope", async () => {
+    const requests: string[] = [];
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const name = url.pathname.split("/").pop()!;
+      const label = init?.method === "HEAD" ? "count" : name === "get_filter_counts" ? "facets" : "page";
+      requests.push(`${label}:start`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      requests.push(`${label}:end`);
+      if (label === "count") return new Response(null, { status: 206, headers: { "content-range": "0-0/401" } });
+      if (label === "facets") return new Response(JSON.stringify({ total: 401 }), { status: 200, headers: { "Content-Type": "application/json" } });
+      return new Response(JSON.stringify([{ id: "a1", filename: "full.psd", relative_path: "art/full.psd" }]), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = createClient("https://example.supabase.co", "test-key", {
+      global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
+    });
+    rpc.mockImplementation((...args) => (client.rpc as any)(...args));
+    const page = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
+    const facets = useFilterCounts(filters({ tagFilter: "blue" })) as unknown as { queryFn: () => Promise<any> };
+    const [pageResult, facetResult] = await Promise.all([page.queryFn(), facets.queryFn()]);
+    expect(pageResult.totalCount).toBe(401);
+    expect(facetResult.total).toBe(401);
+    expect(requests.filter((entry) => entry.endsWith(":start"))).toHaveLength(3);
+    for (let i = 0; i < requests.length; i += 2) {
+      expect(requests[i].replace(":start", "")).toBe(requests[i + 1].replace(":end", ""));
+    }
+    expect(requests.indexOf("count:start")).toBeGreaterThan(requests.indexOf("page:end"));
+  });
+
+  it("surfaces a failed total instead of reporting a false empty library", async () => {
+    installClient(true);
+    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
+    await expect(options.queryFn()).rejects.toBeTruthy();
+  });
+
+  it("uses the same narrow count for standalone library totals", async () => {
+    const fetch = installClient();
+    const options = useAssetCount(filters({ tagFilter: "blue" })) as unknown as { queryFn: () => Promise<number> };
+    expect(await options.queryFn()).toBe(401);
+    expect(fetch.mock.calls).toHaveLength(1);
+    expect(fetch.mock.calls[0][1]?.method).toBe("HEAD");
+  });
+
+  it("forwards category and file-status choices to facet counts", async () => {
+    rpc.mockResolvedValue({ data: { total: 0 }, error: null });
+    const options = useFilterCounts(filters({ tagFilter: "blue", productCategory: [" Wall ", "invalid"], fileStatus: ["has_preview"] })) as unknown as { queryFn: () => Promise<any> };
+    await options.queryFn();
+    expect(rpc).toHaveBeenCalledWith("get_filter_counts", { p_filters: { tagFilter: "blue", productCategory: ["Wall"], fileStatus: ["has_preview"] } });
+  });
+});
+
+describe("narrow exact counts preserve the library scope", () => {
+  it("sends a real HEAD through the SDK, rather than a POST returning all IDs", async () => {
+    const fetch = vi.fn(async () => new Response(null, {
+      status: 206, headers: { "content-range": "0-0/27146" },
+    }));
+    const client = createClient("https://example.supabase.co", "test-key", {
+      global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
+    });
+    rpc.mockImplementation((...args) => (client.rpc as any)(...args));
+    const result = await buildAssetCountQuery(filters({ tagFilter: "blue" }), "2020-01-01", null, null, true);
+    expect(result.count).toBe(27146);
+    expect(result.data).toBeNull();
+    const [url, init] = fetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.method).toBe("HEAD");
+    expect(init.body).toBeUndefined();
+    const params = new URL(url).searchParams;
+    expect(JSON.parse(params.get("p_filters")!)).toEqual({ tagFilter: "blue" });
+    expect(params.get("select")).toBe("id");
+    expect(params.get("limit")).toBe("1");
+    expect(params.get("is_deleted")).toBe("eq.false");
+    expect(new Headers(init.headers).get("Prefer")).toContain("count=exact");
+  });
+
+  function queryRecorder() {
+    const query: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const method of ["select", "eq", "in", "or", "overlaps", "contains", "range"]) {
+      query[method] = vi.fn(() => query);
+    }
+    rpc.mockReturnValue(query);
+    from.mockReturnValue(query);
+    return query;
+  }
+
+  it("uses an ID-only HEAD with exact count and keeps every additional filter", () => {
+    const query = queryRecorder();
+    const input = filters({
+      tagFilter: "blue", licensorId: "l1", propertyId: "p1", search: "mug",
+      stage: ["dev"], customer: "c1", program: "summer", fileType: ["psd"],
+      contentType: ["product_photo"], productMaterial: ["cotton"], status: ["ready"],
+      workflowStatus: ["approved"], isLicensed: true, assetType: ["artwork"],
+      artSource: ["original"], productCategory: ["mug"], fileStatus: ["has_preview"],
+    });
+    buildAssetCountQuery(input, "2021-01-01", ["a1", "a2"], null, true);
+    expect(rpc).toHaveBeenCalledWith("filter_effective_assets", {
+      p_filters: JSON.stringify({ tagFilter: "blue", licensorId: "l1", propertyId: "p1" }),
+    }, { head: true, count: "exact" });
+    expect(query.select).toHaveBeenCalledWith("id");
+    expect(query.range).toHaveBeenCalledWith(0, 0);
+    expect(query.eq.mock.calls).toEqual([
+      ["is_deleted", false], ["customer_id", "c1"], ["program", "summer"], ["is_licensed", true],
+    ]);
+    expect(query.in.mock.calls).toEqual([
+      ["id", ["a1", "a2"]], ["stage", ["dev"]], ["file_type", ["psd"]],
+      ["content_type", ["product_photo"]], ["status", ["ready"]],
+      ["workflow_status", ["approved"]], ["asset_type", ["artwork"]], ["art_source", ["original"]],
+    ]);
+    expect(query.overlaps).toHaveBeenCalledWith("product_material", ["cotton"]);
+    expect(query.contains).not.toHaveBeenCalled();
+    expect(query.or).toHaveBeenCalledWith("thumbnail_url.not.is.null");
+    expect(query.or).toHaveBeenCalledWith(
+      "modified_at.gte.2021-01-01,file_created_at.gte.2021-01-01,thumbnail_url.not.is.null",
+    );
+  });
+
+  it("retains keyword fallback and an empty search-result set", () => {
+    const query = queryRecorder();
+    buildAssetCountQuery(filters({ search: "mug", tagFilter: "blue" }), "2020-01-01", undefined, "filename.ilike.%cup%", true);
+    expect(query.or).toHaveBeenCalledWith("filename.ilike.%cup%");
+    buildAssetCountQuery(filters({ search: "mug" }), "2020-01-01", [], null, false);
+    expect(query.in).toHaveBeenCalledWith("id", ["00000000-0000-0000-0000-000000000000"]);
+  });
+
+  it("keeps direct asset filters when the effective contract is not selected", () => {
+    const query = queryRecorder();
+    buildAssetCountQuery(filters({ tagFilter: "blue", licensorId: "l1", propertyId: "p1" }), "2020-01-01", null, null, false);
+    expect(from).toHaveBeenCalledWith("assets");
+    expect(query.select).toHaveBeenCalledWith("id", { count: "exact", head: true });
+    expect(query.eq).toHaveBeenCalledWith("licensor_id", "l1");
+    expect(query.eq).toHaveBeenCalledWith("property_id", "p1");
+    expect(query.contains).toHaveBeenCalledWith("tags", ["blue"]);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});
+
 describe("which filters are group-owned", () => {
   it("recognises a tag filter as group-owned", () => {
     expect(wouldNeedEffectiveScope(filters({ tagFilter: "drinkware" }))).toBe(true);
@@ -73,26 +279,26 @@ describe("which filters are group-owned", () => {
   });
 });
 
-describe("the contract is disabled until it meets its performance gate", () => {
-  it("routes nothing through filter_effective_assets while the gate is off", () => {
-    // Re-measured 2026-09-02: the identity count was fixed by shared-db#2054,
-    // but filter_effective_assets now times out on EVERY call — five rows, no
-    // filter, no count — and the tag facet count fails 8 times out of 8.
-    // See shared-db#2138.
-    expect(needsEffectiveScope(filters({ tagFilter: "drinkware" }))).toBe(false);
-    expect(needsEffectiveScope(filters({ licensorId: "l1" }))).toBe(false);
-    expect(needsEffectiveScope(filters({ propertyId: "p1" }))).toBe(false);
+describe("the qualified contract routes group-owned filters", () => {
+  it("routes group-owned filters through filter_effective_assets", () => {
+    expect(needsEffectiveScope(filters({ tagFilter: "drinkware" }))).toBe(true);
+    expect(needsEffectiveScope(filters({ licensorId: "l1" }))).toBe(true);
+    expect(needsEffectiveScope(filters({ propertyId: "p1" }))).toBe(true);
   });
 
   it("names the blocking issue next to the switch, so it cannot be flipped blind", async () => {
     const fs = await import("node:fs/promises");
     const source = await fs.readFile("src/hooks/useAssets.ts", "utf8");
-    expect(source).toMatch(/EFFECTIVE_SCOPE_CONTRACT_READY = false/);
+    expect(source).toMatch(/EFFECTIVE_SCOPE_CONTRACT_READY = true/);
     expect(source).toMatch(/shared-db#2138/);
   });
 });
 
 describe("what is handed to the contract", () => {
+  it("delegates only supported category choices with the existing path semantics", () => {
+    expect(buildEffectiveFilterPayload(filters({ tagFilter: "blue", productCategory: [" Wall ", "invalid"] })))
+      .toEqual({ tagFilter: "blue", productCategory: ["Wall"] });
+  });
   it("passes exactly the three group-owned filters and nothing else", () => {
     const payload = buildEffectiveFilterPayload(filters({
       tagFilter: "drinkware",

--- a/src/test/effective-asset-filtering.test.ts
+++ b/src/test/effective-asset-filtering.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/integrations/supabase/client", () => ({
 }));
 
 import {
+  runEffectiveScopeQuery,
   buildEffectiveFilterPayload,
   buildAssetCountQuery,
   needsEffectiveScope,
@@ -81,8 +82,8 @@ describe("active grouped library requests", () => {
 
   it("retains full page rows and exact totals while separating the requests", async () => {
     const fetch = installClient();
-    const options = useAssets(filters({ tagFilter: "blue", stage: ["dev"], productCategory: ["Wall"] }), "modified_at", "desc", 1) as unknown as { queryFn: () => Promise<any> };
-    const result = await options.queryFn();
+    const options = useAssets(filters({ tagFilter: "blue", stage: ["dev"], productCategory: ["Wall"] }), "modified_at", "desc", 1) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    const result = await options.queryFn({ signal: new AbortController().signal });
     expect(result).toEqual({ assets: [{ id: "a1", filename: "full.psd", relative_path: "art/full.psd", file_size: 123 }], totalCount: 401, pageSize: 200, page: 1 });
     const page = fetch.mock.calls.find(([, init]) => init?.method === "POST")!;
     const head = fetch.mock.calls.find(([, init]) => init?.method === "HEAD")!;
@@ -117,8 +118,8 @@ describe("active grouped library requests", () => {
       global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
     });
     rpc.mockImplementation((...args) => (client.rpc as any)(...args));
-    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
-    const result = options.queryFn();
+    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    const result = options.queryFn({ signal: new AbortController().signal });
     await vi.waitFor(() => expect(methods).toEqual(["POST"]));
     releasePage();
     await expect(result).resolves.toMatchObject({ totalCount: 401 });
@@ -144,9 +145,9 @@ describe("active grouped library requests", () => {
       global: { fetch }, auth: { persistSession: false, autoRefreshToken: false },
     });
     rpc.mockImplementation((...args) => (client.rpc as any)(...args));
-    const page = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
-    const facets = useFilterCounts(filters({ tagFilter: "blue" })) as unknown as { queryFn: () => Promise<any> };
-    const [pageResult, facetResult] = await Promise.all([page.queryFn(), facets.queryFn()]);
+    const page = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    const facets = useFilterCounts(filters({ tagFilter: "blue" })) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    const [pageResult, facetResult] = await Promise.all([page.queryFn({ signal: new AbortController().signal }), facets.queryFn({ signal: new AbortController().signal })]);
     expect(pageResult.totalCount).toBe(401);
     expect(facetResult.total).toBe(401);
     expect(requests.filter((entry) => entry.endsWith(":start"))).toHaveLength(3);
@@ -158,22 +159,23 @@ describe("active grouped library requests", () => {
 
   it("surfaces a failed total instead of reporting a false empty library", async () => {
     installClient(true);
-    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: () => Promise<any> };
-    await expect(options.queryFn()).rejects.toBeTruthy();
+    const options = useAssets(filters({ tagFilter: "blue" }), "modified_at", "desc", 0) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    await expect(options.queryFn({ signal: new AbortController().signal })).rejects.toBeTruthy();
   });
 
   it("uses the same narrow count for standalone library totals", async () => {
     const fetch = installClient();
-    const options = useAssetCount(filters({ tagFilter: "blue" })) as unknown as { queryFn: () => Promise<number> };
-    expect(await options.queryFn()).toBe(401);
+    const options = useAssetCount(filters({ tagFilter: "blue" })) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<number> };
+    expect(await options.queryFn({ signal: new AbortController().signal })).toBe(401);
     expect(fetch.mock.calls).toHaveLength(1);
     expect(fetch.mock.calls[0][1]?.method).toBe("HEAD");
   });
 
   it("forwards category and file-status choices to facet counts", async () => {
-    rpc.mockResolvedValue({ data: { total: 0 }, error: null });
-    const options = useFilterCounts(filters({ tagFilter: "blue", productCategory: [" Wall ", "invalid"], fileStatus: ["has_preview"] })) as unknown as { queryFn: () => Promise<any> };
-    await options.queryFn();
+    const response = Promise.resolve({ data: { total: 0 }, error: null });
+    rpc.mockReturnValue(Object.assign(response, { abortSignal: () => response }));
+    const options = useFilterCounts(filters({ tagFilter: "blue", productCategory: [" Wall ", "invalid"], fileStatus: ["has_preview"] })) as unknown as { queryFn: (context: { signal: AbortSignal }) => Promise<any> };
+    await options.queryFn({ signal: new AbortController().signal });
     expect(rpc).toHaveBeenCalledWith("get_filter_counts", { p_filters: { tagFilter: "blue", productCategory: ["Wall"], fileStatus: ["has_preview"] } });
   });
 });
@@ -348,5 +350,41 @@ describe("the source of truth is not re-imposed after the contract resolves it",
     // second client-side branch here would be a parity risk, not a fix.
     expect(source).toMatch(/supabase\.rpc\("get_filter_counts"/);
     expect(source).not.toMatch(/rpc\("get_effective_filter_counts"/);
+  });
+});
+
+describe("successive filter changes do not queue obsolete effective-scope work", () => {
+  it("skips a superseded query still waiting in the queue and runs the current one", async () => {
+    let finishFirst!: () => void;
+    const first = runEffectiveScopeQuery(() => new Promise<string>((resolve) => { finishFirst = () => resolve("first"); }));
+    const staleController = new AbortController();
+    const staleQuery = vi.fn(async () => "stale");
+    const stale = runEffectiveScopeQuery(staleQuery, staleController.signal);
+    const current = runEffectiveScopeQuery(async () => "current", new AbortController().signal);
+
+    staleController.abort(); // React Query cancels the obsolete filter's query
+    await vi.waitFor(() => expect(finishFirst).toBeTypeOf("function"));
+    finishFirst();
+
+    await expect(first).resolves.toBe("first");
+    await expect(stale).rejects.toMatchObject({ name: "AbortError" });
+    await expect(current).resolves.toBe("current");
+    expect(staleQuery).not.toHaveBeenCalled();
+  });
+
+  it("never starts a query whose signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const query = vi.fn(async () => "never");
+    await expect(runEffectiveScopeQuery(query, controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+    expect(query).not.toHaveBeenCalled();
+    await expect(runEffectiveScopeQuery(async () => "next")).resolves.toBe("next");
+  });
+
+  it("passes the cancellation signal into every queued page, count, and facet request", async () => {
+    const { readFileSync } = await import("node:fs");
+    const source = readFileSync("src/hooks/useAssets.ts", "utf8");
+    expect(source.match(/runEffectiveScopeQuery\(/g)?.length).toBe(4); // page, count, standalone count, facets
+    expect(source.match(/\.abortSignal\(signal\)/g)?.length).toBe(4);
   });
 });


### PR DESCRIPTION
Closes #127. Refs u2giants/shared-db#2501.

- Full rows come only for the visible page; the exact total is a narrow ID HEAD count with the identical scope.
- Effective-scope page, facet and count RPCs run serially so they do not contend into the 8-second statement limit.
- React Query's cancel signal aborts superseded requests and skips obsolete work still queued.
- A failed page no longer starts the count.

Independent review: ai-codex-review run 20260911T130347-109423-5206, APPROVE on 668062b (earlier REJECTs addressed). Focused test 25/25, vite build OK, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)